### PR TITLE
"Fix Bug 1217085: remove the class tip"

### DIFF
--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2015-12-19 09:40-0800\n"
-"PO-Revision-Date: 2015-12-24 14:27+0000\n"
+"PO-Revision-Date: 2015-12-24 14:47+0000\n"
 "Last-Translator: Teo Życzkowski <leszekz@gmail.com>\n"
 "Language-Team: none\n"
 "Language: pl\n"
@@ -3634,41 +3634,39 @@ msgstr "Podana nazwa użytkownika już istnieje."
 
 #: kuma/users/apps.py:24
 msgid "User"
-msgstr ""
+msgstr "Użytkownik"
 
 #: kuma/users/apps.py:69
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "You have completed the first step of <a href=\"%s\">getting started with "
 "MDN</a>"
-msgstr ""
-"Tworząc profil wykonałeś/wykonałaś <a href=\"%(started_link)s\">pierwszy "
-"kroku na MDN</a>."
+msgstr "Wykonano pierwszy krok z <a href=\"%s\">przyłączenia sie do MDN</a>"
 
 #: kuma/users/backends.py:32
 msgid "algorithm"
-msgstr ""
+msgstr "algorytm"
 
 #: kuma/users/backends.py:33
 msgid "salt"
-msgstr ""
+msgstr "salt"
 
 #: kuma/users/backends.py:34
 msgid "hash"
-msgstr ""
+msgstr "hash"
 
 #: kuma/users/constants.py:6
 msgid ""
 "Username may contain only letters, numbers, and these characters: . - _ +"
-msgstr ""
+msgstr "Nazwa użytkownika może zawierać tylko litery, cyfry i znaki: . - _ +"
 
 #: kuma/users/forms.py:23
 msgid "You must agree to the privacy policy."
-msgstr ""
+msgstr "Musisz zaakceptować zasady ochrony prywatności."
 
 #: kuma/users/forms.py:38
 msgid "Plain text"
-msgstr ""
+msgstr "Zwykły tekst"
 
 #: kuma/users/forms.py:40
 msgid "Send me the newsletter"
@@ -3676,30 +3674,29 @@ msgstr "Wyślij mi biuletyn"
 
 #: kuma/users/forms.py:42
 msgid "Preferred format"
-msgstr ""
+msgstr "Preferowany format"
 
 #: kuma/users/forms.py:47 kuma/users/signup.py:32
 msgid "I agree"
-msgstr ""
+msgstr "Zgadzam się"
 
 #: kuma/users/forms.py:50
 msgid "Your country"
-msgstr ""
+msgstr "Kraj"
 
 #: kuma/users/forms.py:151 kuma/users/models.py:41
 msgid "Timezone"
-msgstr ""
+msgstr "Strefa czasowa"
 
 #: kuma/users/forms.py:157
 msgid "Beta tester"
-msgstr ""
+msgstr "Beta tester"
 
 #: kuma/users/forms.py:161 kuma/users/templates/users/user_detail.html:87
 msgid "Interests"
 msgstr "Zainteresowania"
 
 #: kuma/users/forms.py:167
-#, fuzzy
 msgid "Expertise"
 msgstr "Obszary wiedzy specjalistycznej"
 
@@ -3710,7 +3707,7 @@ msgstr "Nazwa użytkownika"
 #: kuma/users/forms.py:180 kuma/users/models.py:139
 #: kuma/users/templates/users/user_detail.html:117
 msgid "Website"
-msgstr ""
+msgstr "Witryna"
 
 #: kuma/users/forms.py:189 kuma/users/models.py:154
 #: kuma/users/templates/users/user_detail.html:121
@@ -3728,12 +3725,12 @@ msgstr "GitHub"
 #: kuma/users/forms.py:207 kuma/users/models.py:169
 #: kuma/users/templates/users/user_detail.html:135
 msgid "Stack Overflow"
-msgstr ""
+msgstr "Stack Overflow"
 
 #: kuma/users/forms.py:216 kuma/users/models.py:159
 #: kuma/users/templates/users/user_detail.html:139
 msgid "LinkedIn"
-msgstr ""
+msgstr "LinkedIn"
 
 #: kuma/users/forms.py:225 kuma/users/models.py:144
 #: kuma/users/templates/users/user_detail.html:143
@@ -3748,42 +3745,42 @@ msgstr "Facebook"
 
 #: kuma/users/forms.py:266
 msgid "Areas of expertise must be a subset of interests"
-msgstr ""
+msgstr "Obszary wiedzy muszą być podzestawem zainteresowań"
 
 #: kuma/users/forms.py:275
 msgid "This field cannot be blank."
-msgstr ""
+msgstr "To pole nie może pozostać puste."
 
 #: kuma/users/forms.py:281
 msgid "Username already in use."
-msgstr ""
+msgstr "Nazwa użytkownika jest już zajęta."
 
 #: kuma/users/helpers.py:35
 #, python-format
 msgid "Banned on %(ban_date)s by %(ban_admin)s."
-msgstr ""
+msgstr "Zablokowany na %(ban_date)s przez %(ban_admin)s."
 
 #: kuma/users/helpers.py:42
 msgid "Banned"
-msgstr ""
+msgstr "Zablokowany"
 
 #: kuma/users/helpers.py:49
 msgid "Ban User"
-msgstr ""
+msgstr "Blokowanie użytkowników"
 
 #: kuma/users/helpers.py:60
 msgid "Admin"
-msgstr ""
+msgstr "Administrator"
 
 #: kuma/users/models.py:29
 #, python-format
 msgid "%(banned_user)s banned by %(banned_by)s"
-msgstr ""
+msgstr "%(banned_user)s zablokowany przez %(banned_by)s"
 
 #: kuma/users/models.py:32
 #, python-format
 msgid "%s (no longer active)"
-msgstr ""
+msgstr "%s (nie jest już aktywy)"
 
 #: kuma/users/models.py:51
 msgid "Language"
@@ -3798,14 +3795,16 @@ msgid ""
 "This URL has an invalid format. Valid URLs look like "
 "http://example.com/my_page."
 msgstr ""
+"Ten adres URL ma nieprawidłowy format. Prawidłowy adres URL wygląda jak "
+"http://example.com/my_page."
 
 #: kuma/users/models.py:70
 msgid "Name"
-msgstr ""
+msgstr "Nazwa"
 
 #: kuma/users/models.py:75
 msgid "Organization"
-msgstr ""
+msgstr "Organizacja"
 
 #: kuma/users/models.py:80
 msgid "Location"
@@ -3817,7 +3816,7 @@ msgstr "Informacje o mnie"
 
 #: kuma/users/models.py:89
 msgid "IRC nickname"
-msgstr ""
+msgstr "Pseudonim IRC"
 
 #: kuma/users/models.py:94
 #: kuma/wiki/templates/wiki/confirm_revision_revert.html:27
@@ -3828,35 +3827,35 @@ msgstr "Etykiety"
 
 #: kuma/users/models.py:102
 msgid "Enter a valid website URL."
-msgstr ""
+msgstr "Wprowadź prawidłowy adres URL strony."
 
 #: kuma/users/models.py:107
 msgid "Enter a valid Twitter URL."
-msgstr ""
+msgstr "Wprowadź prawidłowy adres URL Twittera."
 
 #: kuma/users/models.py:112
 msgid "Enter a valid GitHub URL."
-msgstr ""
+msgstr "Wprowadź prawidłowy adres URL GitHuba."
 
 #: kuma/users/models.py:117
 msgid "Enter a valid Stack Overflow URL."
-msgstr ""
+msgstr "Wprowadź prawidłowy adres URL Stack Overflow."
 
 #: kuma/users/models.py:122
 msgid "Enter a valid LinkedIn URL."
-msgstr ""
+msgstr "Wprowadź prawidłowy adres URL LinkedIn."
 
 #: kuma/users/models.py:127
 msgid "Enter a valid Mozillians URL."
-msgstr ""
+msgstr "Wprowadź prawidłowy adres URL Mozillian."
 
 #: kuma/users/models.py:132
 msgid "Enter a valid Facebook URL."
-msgstr ""
+msgstr "Wprowadź prawidłowy adres URL Facebooka."
 
 #: kuma/users/signup.py:7
 msgid "Username is required."
-msgstr ""
+msgstr "Nazwa użytkownika jest wymagana."
 
 #: kuma/users/signup.py:8
 #, python-format
@@ -3878,7 +3877,7 @@ msgstr ""
 
 #: kuma/users/signup.py:13
 msgid "You must agree to the terms of use."
-msgstr ""
+msgstr "Musisz zaakceptować regulamin."
 
 #: kuma/users/tasks.py:38 kuma/users/templates/users/email/welcome/html.ltxt:6
 msgid "Take the next step to get involved on MDN!"
@@ -3891,7 +3890,7 @@ msgstr "Adres e-mail"
 #: kuma/users/views.py:295
 #, python-format
 msgid "%(email)s <b>Verified</b>"
-msgstr ""
+msgstr "%(email)s <b>Zweryfikowano</b>"
 
 #: kuma/users/views.py:298
 #, python-format

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2015-12-19 09:40-0800\n"
-"PO-Revision-Date: 2015-12-24 13:43+0000\n"
+"PO-Revision-Date: 2015-12-24 14:27+0000\n"
 "Last-Translator: Teo Życzkowski <leszekz@gmail.com>\n"
 "Language-Team: none\n"
 "Language: pl\n"
@@ -2163,7 +2163,7 @@ msgstr "Początek"
 
 #: kuma/demos/templates/admin/demos/submission/censor_selected_confirmation.html:9
 msgid "Censor multiple objects"
-msgstr ""
+msgstr "Cenzoruj wiele obiektów"
 
 #: kuma/demos/templates/admin/demos/submission/censor_selected_confirmation.html:14
 #, python-format
@@ -2171,14 +2171,16 @@ msgid ""
 "Are you sure you want to censor the selected %(object_name)s objects? This "
 "cannot be reversed."
 msgstr ""
+"Czy na pewno chcesz cenzurować wybrane %(object_name)s obiektów? Tej "
+"operacji nie można odwrócić."
 
 #: kuma/demos/templates/admin/demos/submission/censor_selected_confirmation.html:23
 msgid "Explanation URL (optional):"
-msgstr ""
+msgstr "Adres URL zawierający wyjaśnienie (opcjonalne):"
 
 #: kuma/demos/templates/admin/demos/submission/censor_selected_confirmation.html:31
 msgid "Yes, I'm sure"
-msgstr ""
+msgstr "Tak, na pewno"
 
 #: kuma/demos/templates/demos/delete.html:10
 #: kuma/demos/templates/demos/detail.html:9
@@ -2389,9 +2391,9 @@ msgstr[2] "To demo było oglądane %(num)s razy"
 #, python-format
 msgid "%(num)s view"
 msgid_plural "%(num)s views"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%(num)s odsłona"
+msgstr[1] "%(num)s odsłony"
+msgstr[2] "%(num)s odsłon"
 
 #: kuma/demos/templates/demos/detail.html:166
 #: kuma/demos/templates/demos/elements/submission_thumb.html:16
@@ -2406,9 +2408,9 @@ msgstr[2] "%(num)s osobom podoba się to demo"
 #, python-format
 msgid "%(num)s like"
 msgid_plural "%(num)s likes"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%(num)s osoba lubi to"
+msgstr[1] "%(num)s osoby lubią to"
+msgstr[2] "%(num)s osób lubi to"
 
 #: kuma/demos/templates/demos/detail.html:181
 msgid "Edit Demo"
@@ -2638,7 +2640,7 @@ msgstr "autor: %(profile_link)s"
 
 #: kuma/demos/templates/demos/launch.html:77
 msgid "Back"
-msgstr ""
+msgstr "Wróć"
 
 #: kuma/demos/templates/demos/launch.html:86
 msgid "Remove this toolbar"
@@ -2958,9 +2960,9 @@ msgstr "Zobacz profil %(display_name)s"
 #, python-format
 msgid "%(num)s Demo"
 msgid_plural "%(num)s Demos"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%(num)s demo"
+msgstr[1] "%(num)s dema"
+msgstr[2] "%(num)s dem"
 
 #: kuma/demos/templates/demos/elements/submission_listing.html:9
 msgid "Sort demos by most recent likes and views"
@@ -3016,7 +3018,7 @@ msgstr "Przejdź do pierwszej strony"
 
 #: kuma/demos/templates/demos/elements/submission_listing.html:58
 msgid "First"
-msgstr ""
+msgstr "Pierwsza"
 
 #: kuma/demos/templates/demos/elements/submission_listing.html:61
 msgid "Go to the previous page"
@@ -3048,6 +3050,8 @@ msgid ""
 "The Mozilla Developer Network (MDN) Fellowship Program invites world-class "
 "web developers to come change the world with Mozilla."
 msgstr ""
+"Program Fellowship z Mozilla Developer Network (MDN) zaprasza światowej "
+"klasy twórców internetowych do zmiany Świata razem z Mozillą."
 
 #: kuma/landing/templates/landing/homepage.html:14
 msgid ""
@@ -3121,7 +3125,7 @@ msgstr "Debugger JavaScript"
 
 #: kuma/landing/templates/landing/homepage.html:94
 msgid "Performance Tools"
-msgstr ""
+msgstr "Narzędzia do oceny wydajności"
 
 #: kuma/landing/templates/landing/homepage.html:99
 msgid "Connect"
@@ -3149,11 +3153,11 @@ msgstr "Dowiedz się o Web Development"
 
 #: kuma/landing/templates/landing/homepage.html:116
 msgid "Get The Browser For Developers Like You"
-msgstr ""
+msgstr "Pobierz przeglądarkę dla programistów takich jak ty"
 
 #: kuma/landing/templates/landing/homepage.html:120
 msgid "Celebrate ten years of documenting your Web."
-msgstr ""
+msgstr "Świętuj dziesięć lat dokumentowania sieci Web."
 
 #: kuma/landing/templates/landing/homepage.html:124
 msgid "Build Open Web Apps"
@@ -3603,30 +3607,30 @@ msgstr "To zawiera niewłaściwą treść."
 
 #: kuma/spam/forms.py:33
 msgid "The form data has not yet been validated. Please try again."
-msgstr ""
+msgstr "Dane z formularza nie zostały jeszcze zatwierdzone. Spróbuj ponownie."
 
 #: kuma/spam/models.py:10
 msgid "created"
 msgstr "utworzono"
 
 #: kuma/users/adapters.py:17
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "Sorry, you must have at least one connected account so you can sign in. To "
 "disconnect this account connect a different one first. To delete your MDN "
 "profile please <a href=\"%(bug_form_url)s\" rel=\"nofollow\">file a bug</a>."
 msgstr ""
-"Jeśli próbowałeś/próbowałaś otworzyć odnośnik do dokumentacji, możesz "
-"zalogować się i utworzyć stronę. Jeśli nie, <a href=\"%(bug_form_url)s\" "
-"rel=\"nofollow\">zgłoś błąd</a>. Dziękujemy!"
+"Aby się logować, musisz mieć przynajmniej jedno działające konto. Aby "
+"wyłączyć to konto musisz zalogować z innego konta. Aby usunąć profil MDN <a "
+"href=\"%(bug_form_url)s\" rel=\"nofollow\">wypełnij zgłoszenie</a>."
 
 #: kuma/users/adapters.py:21
 msgid "An email address cannot be used as a username."
-msgstr ""
+msgstr "Adres e-mail nie może być użyty jako nazwa użytkownika."
 
 #: kuma/users/adapters.py:48
 msgid "The username you entered already exists."
-msgstr ""
+msgstr "Podana nazwa użytkownika już istnieje."
 
 #: kuma/users/apps.py:24
 msgid "User"

--- a/locale/sq/LC_MESSAGES/django.po
+++ b/locale/sq/LC_MESSAGES/django.po
@@ -1,9 +1,10 @@
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2015-12-19 09:40-0800\n"
-"PO-Revision-Date: 2015-11-21 13:22+0300\n"
+"PO-Revision-Date: 2015-12-24 17:45+0000\n"
 "Last-Translator: Besnik Bleta <besnik@programeshqip.org>\n"
 "Language-Team: sq\n"
 "Language: sq\n"
@@ -11,8 +12,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Virtaal 0.7.1\n"
 "Generated-By: Babel 2.0\n"
+"X-Generator: Pontoon\n"
 "X-POOTLE-MTIME: 1425209041.0\n"
 
 #: kuma/actioncounters/models.py:46 kuma/contentflagging/models.py:110
@@ -23,7 +24,8 @@ msgstr "ID objekti"
 msgid "name of the action"
 msgstr "emri i veprimit"
 
-#: kuma/actioncounters/models.py:66 kuma/contentflagging/models.py:127 kuma/demos/models.py:457
+#: kuma/actioncounters/models.py:66 kuma/contentflagging/models.py:127
+#: kuma/demos/models.py:457
 msgid "date last modified"
 msgstr "data e ndryshimit të fundit"
 
@@ -42,7 +44,9 @@ msgstr "Kartelat e këtij lloji s’janë të lejueshme."
 #: kuma/attachments/views.py:147
 #, python-format
 msgid "The file provided is not valid. File must be one of these types: %s."
-msgstr "Kartela e dhënë s’është e vlefshme. Kartela duhet të jetë një prej këtyre llojeve: %s."
+msgstr ""
+"Kartela e dhënë s’është e vlefshme. Kartela duhet të jetë një prej këtyre "
+"llojeve: %s."
 
 #. 'id' is the revision number, 'title' is the title of the document.
 #: kuma/attachments/templates/attachments/attachment_detail.html:3
@@ -54,27 +58,33 @@ msgstr "Bashkëngjitje %(id)s | %(title)s"
 msgid "Attachment Information"
 msgstr "Të dhëna Bashkëngjitjeje"
 
-#: kuma/attachments/templates/attachments/attachment_detail.html:19 kuma/wiki/templates/wiki/revision.html:17
+#: kuma/attachments/templates/attachments/attachment_detail.html:19
+#: kuma/wiki/templates/wiki/revision.html:17
 msgid "Revision slug:"
 msgstr "Identifikues rishikimi:"
 
-#: kuma/attachments/templates/attachments/attachment_detail.html:23 kuma/wiki/templates/wiki/revision.html:21
+#: kuma/attachments/templates/attachments/attachment_detail.html:23
+#: kuma/wiki/templates/wiki/revision.html:21
 msgid "Revision title:"
 msgstr "Titull rishikimi:"
 
-#: kuma/attachments/templates/attachments/attachment_detail.html:27 kuma/wiki/templates/wiki/revision.html:25
+#: kuma/attachments/templates/attachments/attachment_detail.html:27
+#: kuma/wiki/templates/wiki/revision.html:25
 msgid "Revision id:"
 msgstr "ID rishikimi:"
 
-#: kuma/attachments/templates/attachments/attachment_detail.html:31 kuma/wiki/templates/wiki/revision.html:29
+#: kuma/attachments/templates/attachments/attachment_detail.html:31
+#: kuma/wiki/templates/wiki/revision.html:29
 msgid "Created:"
 msgstr "Krijuar më:"
 
-#: kuma/attachments/templates/attachments/attachment_detail.html:35 kuma/wiki/templates/wiki/revision.html:33
+#: kuma/attachments/templates/attachments/attachment_detail.html:35
+#: kuma/wiki/templates/wiki/revision.html:33
 msgid "Creator:"
 msgstr "Krijues:"
 
-#: kuma/attachments/templates/attachments/attachment_detail.html:39 kuma/attachments/templates/attachments/attachment_detail.html:43
+#: kuma/attachments/templates/attachments/attachment_detail.html:39
+#: kuma/attachments/templates/attachments/attachment_detail.html:43
 msgid "MIME Type:"
 msgstr "Lloj MIME:"
 
@@ -87,7 +97,8 @@ msgstr "%(bytes)s bajte"
 msgid "Is approved?"
 msgstr "Është i miratuar?"
 
-#: kuma/attachments/templates/attachments/attachment_detail.html:52 kuma/wiki/templates/wiki/revision.html:38
+#: kuma/attachments/templates/attachments/attachment_detail.html:52
+#: kuma/wiki/templates/wiki/revision.html:38
 msgid "Is current revision?"
 msgstr "Është versioni i tanishëm?"
 
@@ -115,15 +126,21 @@ msgstr "Bashkëngjitje"
 msgid "Learn how to use Attachments"
 msgstr "Mësoni si të përdorni Bashkëngjitjet"
 
-#: kuma/attachments/templates/attachments/includes/attachment_list.html:16 kuma/attachments/templates/attachments/includes/attachment_list.html:23
+#: kuma/attachments/templates/attachments/includes/attachment_list.html:16
+#: kuma/attachments/templates/attachments/includes/attachment_list.html:23
 msgid "Attach Files"
 msgstr "Bashkëngjitni Kartela"
 
 #: kuma/attachments/templates/attachments/includes/attachment_list.html:21
-msgid "This document has no attachments. Images can be attached, and then embedded in the article."
-msgstr "Ky dokument s’ka bashkëngjitje. Figurat mund të bashkëngjiten, dhe mandej të trupëzohen në artikull."
+msgid ""
+"This document has no attachments. Images can be attached, and then embedded "
+"in the article."
+msgstr ""
+"Ky dokument s’ka bashkëngjitje. Figurat mund të bashkëngjiten, dhe mandej të"
+" trupëzohen në artikull."
 
-#: kuma/attachments/templates/attachments/includes/attachment_list.html:33 kuma/attachments/templates/attachments/includes/attachment_list.html:51
+#: kuma/attachments/templates/attachments/includes/attachment_list.html:33
+#: kuma/attachments/templates/attachments/includes/attachment_list.html:51
 msgid "File"
 msgstr "Kartelë"
 
@@ -131,7 +148,9 @@ msgstr "Kartelë"
 msgid "Size"
 msgstr "Madhësi"
 
-#: kuma/attachments/templates/attachments/includes/attachment_list.html:35 kuma/users/templates/users/user_detail.html:181 kuma/wiki/templates/wiki/confirm_revision_revert.html:23
+#: kuma/attachments/templates/attachments/includes/attachment_list.html:35
+#: kuma/users/templates/users/user_detail.html:181
+#: kuma/wiki/templates/wiki/confirm_revision_revert.html:23
 msgid "Date"
 msgstr "Datë"
 
@@ -139,11 +158,14 @@ msgstr "Datë"
 msgid "Attached by"
 msgstr "Bashkëngjitur nga"
 
-#: kuma/attachments/templates/attachments/includes/attachment_list.html:52 kuma/users/models.py:65 kuma/wiki/models.py:1828
+#: kuma/attachments/templates/attachments/includes/attachment_list.html:52
+#: kuma/users/models.py:65 kuma/wiki/models.py:1828
 msgid "Title"
 msgstr "Titull"
 
-#: kuma/attachments/templates/attachments/includes/attachment_list.html:53 kuma/authkeys/templates/authkeys/delete.html:9 kuma/authkeys/templates/authkeys/history.html:10
+#: kuma/attachments/templates/attachments/includes/attachment_list.html:53
+#: kuma/authkeys/templates/authkeys/delete.html:9
+#: kuma/authkeys/templates/authkeys/history.html:10
 #: kuma/authkeys/templates/authkeys/new.html:36
 msgid "Description"
 msgstr "Përshkrim"
@@ -173,16 +195,23 @@ msgstr "E fshehtë hash"
 msgid "Description of intended use"
 msgstr "Përshkrim i përdorimit të synuar"
 
-#: kuma/authkeys/templates/authkeys/delete.html:7 kuma/authkeys/templates/authkeys/history.html:8 kuma/authkeys/templates/authkeys/new.html:34
+#: kuma/authkeys/templates/authkeys/delete.html:7
+#: kuma/authkeys/templates/authkeys/history.html:8
+#: kuma/authkeys/templates/authkeys/new.html:34
 msgid "Created"
 msgstr "U krijua"
 
-#: kuma/authkeys/templates/authkeys/delete.html:15 kuma/wiki/templates/wiki/confirm_document_delete.html:15 kuma/wiki/templates/wiki/confirm_document_delete.html:38
+#: kuma/authkeys/templates/authkeys/delete.html:15
+#: kuma/wiki/templates/wiki/confirm_document_delete.html:15
+#: kuma/wiki/templates/wiki/confirm_document_delete.html:38
 msgid "Delete"
 msgstr "Fshije"
 
-#: kuma/authkeys/templates/authkeys/delete.html:16 kuma/authkeys/templates/authkeys/new.html:17 kuma/wiki/templates/wiki/confirm_document_delete.html:39
-#: kuma/wiki/templates/wiki/confirm_revision_revert.html:40 kuma/wiki/templates/wiki/move.html:93 templates/tidings/unsubscribe.html:13
+#: kuma/authkeys/templates/authkeys/delete.html:16
+#: kuma/authkeys/templates/authkeys/new.html:17
+#: kuma/wiki/templates/wiki/confirm_document_delete.html:39
+#: kuma/wiki/templates/wiki/confirm_revision_revert.html:40
+#: kuma/wiki/templates/wiki/move.html:93 templates/tidings/unsubscribe.html:13
 msgid "Cancel"
 msgstr "Anuloje"
 
@@ -192,11 +221,16 @@ msgstr "Ky kyç s’është përdorur ende."
 
 #: kuma/authkeys/templates/authkeys/list.html:8
 msgid ""
-"These are your API keys. They're useful for building applications that perform tasks on MDN on your behalf. If you have stopped using any of them, or suspect one has been exposed to parties you "
-"don't trust with your account delete the key. It's easy to create a replacement key at any time."
+"These are your API keys. They're useful for building applications that "
+"perform tasks on MDN on your behalf. If you have stopped using any of them, "
+"or suspect one has been exposed to parties you don't trust with your account"
+" delete the key. It's easy to create a replacement key at any time."
 msgstr ""
-"Këto janë kyçet tuaja për API. Janë të dobishëm për krijim aplikacionesh që përmbushin te MDN-ja punë në emrin tuaj. Nëse keni reshtur së përdoruri ndonjë prej tyre, ose dyshoni se ndonjë prej tyre "
-"i është ekspozuar palëve të cilave s’u zini besë për llogarinë tuaj, fshijeni kyçin. Krijimi i një kyçi zëvendësues është i lehtë në çfarëdo kohe."
+"Këto janë kyçet tuaja për API. Janë të dobishëm për krijim aplikacionesh që "
+"përmbushin te MDN-ja punë në emrin tuaj. Nëse keni reshtur së përdoruri "
+"ndonjë prej tyre, ose dyshoni se ndonjë prej tyre i është ekspozuar palëve "
+"të cilave s’u zini besë për llogarinë tuaj, fshijeni kyçin. Krijimi i një "
+"kyçi zëvendësues është i lehtë në çfarëdo kohe."
 
 #: kuma/authkeys/templates/authkeys/list.html:14
 msgid "Create a new key"
@@ -217,16 +251,23 @@ msgstr "Historik (%(count)s)"
 
 #: kuma/authkeys/templates/authkeys/list.html:35
 #, python-format
-msgid "You need a special permission to use API keys. You may request permission by <a href=\"%(bugzilla_url)s\">filing a bug</a>."
-msgstr "Ju duhet një leje speciale për të përdorur kyçe API. Leje mund të kërkoni <a href=\"%(bugzilla_url)s\">duke përdorur këtë</a>."
+msgid ""
+"You need a special permission to use API keys. You may request permission by"
+" <a href=\"%(bugzilla_url)s\">filing a bug</a>."
+msgstr ""
+"Ju duhet një leje speciale për të përdorur kyçe API. Leje mund të kërkoni <a"
+" href=\"%(bugzilla_url)s\">duke përdorur këtë</a>."
 
 #: kuma/authkeys/templates/authkeys/new.html:7
 msgid ""
-"<p>Describe your intended use for this key, below. <p><strong>NOTE:</strong> This will be your only means of identifying this key later, other than the date and time of its creation. So, be as "
-"clear as you can.</p>"
+"<p>Describe your intended use for this key, below. <p><strong>NOTE:</strong>"
+" This will be your only means of identifying this key later, other than the "
+"date and time of its creation. So, be as clear as you can.</p>"
 msgstr ""
-"<p>Përshkruani më poshtë përdorimin që keni menduar për këtë kyçin. <p><strong>SHËNIM:</strong> Kjo do të jetë e vetmja mënyrë për identifikimin e këtij kyçi më vonë, përveç datës dhe kohës së "
-"krijimit të tij. Ndaj, jini sa më i qartë që të mundet.</p>"
+"<p>Përshkruani më poshtë përdorimin që keni menduar për këtë kyçin. "
+"<p><strong>SHËNIM:</strong> Kjo do të jetë e vetmja mënyrë për identifikimin"
+" e këtij kyçi më vonë, përveç datës dhe kohës së krijimit të tij. Ndaj, jini"
+" sa më i qartë që të mundet.</p>"
 
 #: kuma/authkeys/templates/authkeys/new.html:16
 msgid "Create"
@@ -235,12 +276,19 @@ msgstr "Krijo"
 #: kuma/authkeys/templates/authkeys/new.html:20
 #, python-format
 msgid ""
-"<p>Your new key has been created. Please make a note of the details below (e.g. by copying them into your application's settings). This information will never be displayed again, and cannot be "
-"recovered if lost.</p> <p><strong>NOTE:</strong> When you're done, <a class=\"button\" href=\"%(list_url)s\">return to the key list</a>. Reloading this page will create a new key.</p>"
+"<p>Your new key has been created. Please make a note of the details below "
+"(e.g. by copying them into your application's settings). This information "
+"will never be displayed again, and cannot be recovered if lost.</p> "
+"<p><strong>NOTE:</strong> When you're done, <a class=\"button\" "
+"href=\"%(list_url)s\">return to the key list</a>. Reloading this page will "
+"create a new key.</p>"
 msgstr ""
-"<p>Kyçi juaj i ri u krijua. Ju lutemi, mbani shënim hollësitë më poshtë (p.sh. duke i kopjuar ato te rregullimet e aplikacionit tuaj). Këto të dhëna s’do të shfaqen më kurrë sërish, dhe s’mund të "
-"rikthehet, po humbi.</p> <p><strong>SHËNIM:</strong> Pasi të keni mbaruar, <a class=\"button\" href=\"%(list_url)s\">kthehuni te lista e kyçeve</a>. Ringarkimi i kësaj faqeje do të krijonte një kyç "
-"të ri.</p>"
+"<p>Kyçi juaj i ri u krijua. Ju lutemi, mbani shënim hollësitë më poshtë "
+"(p.sh. duke i kopjuar ato te rregullimet e aplikacionit tuaj). Këto të dhëna"
+" s’do të shfaqen më kurrë sërish, dhe s’mund të rikthehet, po humbi.</p> "
+"<p><strong>SHËNIM:</strong> Pasi të keni mbaruar, <a class=\"button\" "
+"href=\"%(list_url)s\">kthehuni te lista e kyçeve</a>. Ringarkimi i kësaj "
+"faqeje do të krijonte një kyç të ri.</p>"
 
 #: kuma/authkeys/templates/authkeys/new.html:30
 msgid "Key ID"
@@ -314,8 +362,12 @@ msgid "%(object)s has been flagged %(flag_type)s"
 msgstr "%(object)s i është vënë shenjë si %(flag_type)s"
 
 #: kuma/contentflagging/templates/contentflagging/email/flagged.ltxt:6
-msgid "To change the status of this flag, click the following link, or paste it into your browser's location bar:"
-msgstr "Për të ndryshuar gjendjen e kësaj flamurke, klikoni mbi lidhjen vijuese, ose hidheni atë te shtylla e vendeve te shfletuesi juaj:"
+msgid ""
+"To change the status of this flag, click the following link, or paste it "
+"into your browser's location bar:"
+msgstr ""
+"Për të ndryshuar gjendjen e kësaj flamurke, klikoni mbi lidhjen vijuese, ose"
+" hidheni atë te shtylla e vendeve te shfletuesi juaj:"
 
 #: kuma/core/apps.py:16
 msgid "Core"
@@ -323,13 +375,21 @@ msgstr "Baza"
 
 #: kuma/core/form_fields.py:57
 #, python-format
-msgid "Ensure this value has at least %(limit_value)s characters (it has %(show_value)s)."
-msgstr "Sigurohuni që kjo vlerë të ketë të paktën %(limit_value)s shenja (ka %(show_value)s)."
+msgid ""
+"Ensure this value has at least %(limit_value)s characters (it has "
+"%(show_value)s)."
+msgstr ""
+"Sigurohuni që kjo vlerë të ketë të paktën %(limit_value)s shenja (ka "
+"%(show_value)s)."
 
 #: kuma/core/form_fields.py:62
 #, python-format
-msgid "Ensure this value has at most %(limit_value)s characters (it has %(show_value)s)."
-msgstr "Sigurohuni që kjo vlerë të ketë të shumtën %(limit_value)s shenja (ka %(show_value)s)."
+msgid ""
+"Ensure this value has at most %(limit_value)s characters (it has "
+"%(show_value)s)."
+msgstr ""
+"Sigurohuni që kjo vlerë të ketë të shumtën %(limit_value)s shenja (ka "
+"%(show_value)s)."
 
 #: kuma/core/helpers.py:109 kuma/demos/helpers.py:305
 #, python-format
@@ -393,7 +453,8 @@ msgstr "Jo"
 msgid "Today at %s"
 msgstr "Sot më %s"
 
-#: kuma/core/sections.py:6 kuma/landing/templates/landing/homepage.html:85 templates/base.html:154
+#: kuma/core/sections.py:6 kuma/landing/templates/landing/homepage.html:85
+#: templates/base.html:154
 msgid "Add-ons"
 msgstr "Shtesa"
 
@@ -405,11 +466,14 @@ msgstr "Mozilla"
 msgid "Apps"
 msgstr "Aplikacione"
 
-#: kuma/core/sections.py:27 kuma/core/translations/search/filter/mobile/name.py:4 kuma/demos/__init__.py:184 kuma/demos/__init__.py:319
+#: kuma/core/sections.py:27
+#: kuma/core/translations/search/filter/mobile/name.py:4
+#: kuma/demos/__init__.py:184 kuma/demos/__init__.py:319
 msgid "Mobile"
 msgstr "Celular"
 
-#: kuma/core/sections.py:34 kuma/landing/templates/landing/promote_buttons.html:117
+#: kuma/core/sections.py:34
+#: kuma/landing/templates/landing/promote_buttons.html:117
 msgid "Web"
 msgstr "Web"
 
@@ -437,7 +501,8 @@ msgstr "Aplikacione të Hapura Web"
 msgid "I'm Learning"
 msgstr "Po Mësoj"
 
-#: kuma/core/translations/search/filter/canvas/name.py:4 kuma/demos/__init__.py:72 kuma/demos/__init__.py:233
+#: kuma/core/translations/search/filter/canvas/name.py:4
+#: kuma/demos/__init__.py:72 kuma/demos/__init__.py:233
 msgid "Canvas"
 msgstr "Canvas"
 
@@ -445,11 +510,15 @@ msgstr "Canvas"
 msgid "Code Samples"
 msgstr "Shembuj Kodi"
 
-#: kuma/core/translations/search/filter/css/name.py:4 kuma/landing/templates/landing/homepage.html:73 kuma/landing/templates/landing/promote_buttons.html:99 templates/base.html:129
+#: kuma/core/translations/search/filter/css/name.py:4
+#: kuma/landing/templates/landing/homepage.html:73
+#: kuma/landing/templates/landing/promote_buttons.html:99
+#: templates/base.html:129
 msgid "CSS"
 msgstr "CSS"
 
-#: kuma/core/translations/search/filter/firefox/name.py:4 kuma/landing/templates/landing/homepage.html:81 templates/base.html:155
+#: kuma/core/translations/search/filter/firefox/name.py:4
+#: kuma/landing/templates/landing/homepage.html:81 templates/base.html:155
 msgid "Firefox"
 msgstr "Firefox"
 
@@ -461,7 +530,8 @@ msgstr "Firefox për Desktop"
 msgid "Firefox for Android"
 msgstr "Firefox-i për Android"
 
-#: kuma/core/translations/search/filter/firefox-os/name.py:4 kuma/landing/templates/landing/homepage.html:82 templates/base.html:157
+#: kuma/core/translations/search/filter/firefox-os/name.py:4
+#: kuma/landing/templates/landing/homepage.html:82 templates/base.html:157
 msgid "Firefox OS"
 msgstr "Firefox OS"
 
@@ -473,8 +543,10 @@ msgstr "Lojëra"
 msgid "How-To & Tutorial"
 msgstr "Si-Të & Përkujdesore"
 
-#: kuma/core/translations/search/filter/html/name.py:4 kuma/landing/templates/landing/homepage.html:72 kuma/landing/templates/landing/promote_buttons.html:105 kuma/users/forms.py:37
-#: templates/base.html:128
+#: kuma/core/translations/search/filter/html/name.py:4
+#: kuma/landing/templates/landing/homepage.html:72
+#: kuma/landing/templates/landing/promote_buttons.html:105
+#: kuma/users/forms.py:37 templates/base.html:128
 msgid "HTML"
 msgstr "HTML"
 
@@ -482,7 +554,9 @@ msgstr "HTML"
 msgid "Intermediate"
 msgstr "Mesatar"
 
-#: kuma/core/translations/search/filter/js/name.py:4 kuma/demos/__init__.py:287 kuma/landing/templates/landing/homepage.html:74 kuma/landing/templates/landing/promote_buttons.html:111
+#: kuma/core/translations/search/filter/js/name.py:4
+#: kuma/demos/__init__.py:287 kuma/landing/templates/landing/homepage.html:74
+#: kuma/landing/templates/landing/promote_buttons.html:111
 #: templates/base.html:130
 msgid "JavaScript"
 msgstr "JavaScript"
@@ -491,15 +565,18 @@ msgstr "JavaScript"
 msgid "Marketplace"
 msgstr "Marketplace"
 
-#: kuma/core/translations/search/filter/mathml/name.py:4 templates/base.html:134
+#: kuma/core/translations/search/filter/mathml/name.py:4
+#: templates/base.html:134
 msgid "MathML"
 msgstr "MathML"
 
-#: kuma/core/translations/search/filter/svg/name.py:4 kuma/demos/__init__.py:335
+#: kuma/core/translations/search/filter/svg/name.py:4
+#: kuma/demos/__init__.py:335
 msgid "SVG"
 msgstr "SVG"
 
-#: kuma/core/translations/search/filter/tools/name.py:4 templates/base.html:100
+#: kuma/core/translations/search/filter/tools/name.py:4
+#: templates/base.html:100
 msgid "Tools"
 msgstr "Mjete"
 
@@ -507,7 +584,8 @@ msgstr "Mjete"
 msgid "Web Development"
 msgstr "Programim Web"
 
-#: kuma/core/translations/search/filter/webgl/name.py:4 kuma/demos/__init__.py:121 kuma/demos/__init__.py:351
+#: kuma/core/translations/search/filter/webgl/name.py:4
+#: kuma/demos/__init__.py:121 kuma/demos/__init__.py:351
 msgid "WebGL"
 msgstr "WebGL"
 
@@ -551,27 +629,33 @@ msgstr "Javë"
 msgid "30 days"
 msgstr "30 ditë"
 
-#: kuma/dashboards/forms.py:24 kuma/dashboards/templates/dashboards/revisions.html:14
+#: kuma/dashboards/forms.py:24
+#: kuma/dashboards/templates/dashboards/revisions.html:14
 msgid "Locale:"
 msgstr "Vendore:"
 
-#: kuma/dashboards/forms.py:28 kuma/dashboards/templates/dashboards/revisions.html:19
+#: kuma/dashboards/forms.py:28
+#: kuma/dashboards/templates/dashboards/revisions.html:19
 msgid "User:"
 msgstr "Përdorues:"
 
-#: kuma/dashboards/forms.py:32 kuma/dashboards/templates/dashboards/revisions.html:24
+#: kuma/dashboards/forms.py:32
+#: kuma/dashboards/templates/dashboards/revisions.html:24
 msgid "Topic:"
 msgstr "Temë:"
 
-#: kuma/dashboards/forms.py:34 kuma/dashboards/templates/dashboards/revisions.html:30
+#: kuma/dashboards/forms.py:34
+#: kuma/dashboards/templates/dashboards/revisions.html:30
 msgid "Start Date:"
 msgstr "Datë Fillimi:"
 
-#: kuma/dashboards/forms.py:38 kuma/dashboards/templates/dashboards/revisions.html:35
+#: kuma/dashboards/forms.py:38
+#: kuma/dashboards/templates/dashboards/revisions.html:35
 msgid "End Date:"
 msgstr "Datë Përfundimi:"
 
-#: kuma/dashboards/forms.py:44 kuma/dashboards/templates/dashboards/revisions.html:40
+#: kuma/dashboards/forms.py:44
+#: kuma/dashboards/templates/dashboards/revisions.html:40
 msgid "Preceding Period:"
 msgstr "Periudha Pararendëse:"
 
@@ -579,23 +663,28 @@ msgstr "Periudha Pararendëse:"
 msgid "Revision Dashboard"
 msgstr "Pult Rishikimesh"
 
-#: kuma/dashboards/templates/dashboards/revisions.html:44 kuma/search/templates/search/results.html:210
+#: kuma/dashboards/templates/dashboards/revisions.html:44
+#: kuma/search/templates/search/results.html:210
 msgid "Filter"
 msgstr "Filtroji"
 
-#: kuma/dashboards/templates/dashboards/revisions.html:73 kuma/wiki/templates/wiki/confirm_revision_revert.html:39
+#: kuma/dashboards/templates/dashboards/revisions.html:73
+#: kuma/wiki/templates/wiki/confirm_revision_revert.html:39
 msgid "Revert"
 msgstr "Rikthe"
 
-#: kuma/dashboards/templates/dashboards/revisions.html:73 kuma/wiki/feeds.py:341
+#: kuma/dashboards/templates/dashboards/revisions.html:73
+#: kuma/wiki/feeds.py:341
 msgid "View Page"
 msgstr "Shihni Faqen"
 
-#: kuma/dashboards/templates/dashboards/revisions.html:73 kuma/wiki/feeds.py:344
+#: kuma/dashboards/templates/dashboards/revisions.html:73
+#: kuma/wiki/feeds.py:344
 msgid "Edit Page"
 msgstr "Përpunoni Faqen"
 
-#: kuma/dashboards/templates/dashboards/revisions.html:73 kuma/wiki/feeds.py:365 kuma/wiki/templates/wiki/includes/buttons.html:59
+#: kuma/dashboards/templates/dashboards/revisions.html:73
+#: kuma/wiki/feeds.py:365 kuma/wiki/templates/wiki/includes/buttons.html:59
 msgid "History"
 msgstr "Historik"
 
@@ -617,25 +706,29 @@ msgstr "S’ka rishikime që përputhen me këtë grup filtrash."
 
 #. Please localize 'English' here.
 #. Please replace 'English' with your language.
-#: kuma/dashboards/templates/dashboards/includes/watch_approved.html:8 kuma/dashboards/templates/dashboards/includes/watch_approved.html:11
+#: kuma/dashboards/templates/dashboards/includes/watch_approved.html:8
+#: kuma/dashboards/templates/dashboards/includes/watch_approved.html:11
 msgid "Stop getting emailed when English revisions are approved"
 msgstr "Reshtni së marri email-e kur miratohen rishikime në Anglisht"
 
 #. Please localize 'English' here.
 #. Please replace 'English' with your language.
-#: kuma/dashboards/templates/dashboards/includes/watch_approved.html:20 kuma/dashboards/templates/dashboards/includes/watch_approved.html:23
+#: kuma/dashboards/templates/dashboards/includes/watch_approved.html:20
+#: kuma/dashboards/templates/dashboards/includes/watch_approved.html:23
 msgid "Get emailed when English revisions are approved"
 msgstr "Merrni email kur miratohen rishikimet në Anglisht"
 
 #. Please localize 'English' here.
 #. Please replace 'English' with your language.
-#: kuma/dashboards/templates/dashboards/includes/watch_locale.html:7 kuma/dashboards/templates/dashboards/includes/watch_locale.html:10
+#: kuma/dashboards/templates/dashboards/includes/watch_locale.html:7
+#: kuma/dashboards/templates/dashboards/includes/watch_locale.html:10
 msgid "Stop getting emailed when English reviews are waiting"
 msgstr "Reshtni së marri email-e kur ka rishikime në Anglisht në pritje"
 
 #. Please localize 'English' here.
 #. Please replace 'English' with your language.
-#: kuma/dashboards/templates/dashboards/includes/watch_locale.html:18 kuma/dashboards/templates/dashboards/includes/watch_locale.html:21
+#: kuma/dashboards/templates/dashboards/includes/watch_locale.html:18
+#: kuma/dashboards/templates/dashboards/includes/watch_locale.html:21
 msgid "Get emailed when English reviews are waiting"
 msgstr "Merrni email kur ka rishikime në Anglisht në pritje"
 
@@ -656,20 +749,33 @@ msgid "June 2011"
 msgstr "Qershor 2011"
 
 #: kuma/demos/__init__.py:39
-msgid "CSS3 Animations let you change property values over time, to animate the appearance or position of elements, with no or minimal JavaScript, and with greater control than transitions."
+msgid ""
+"CSS3 Animations let you change property values over time, to animate the "
+"appearance or position of elements, with no or minimal JavaScript, and with "
+"greater control than transitions."
 msgstr ""
-"Animacionet CSS3 ju lejojnë të ndryshoni vlera vetish në funksion të kohës, të krijoni animacione të dukjes ose pozicionit të elementëve, pa ose me minimum JavaScript-i, dhe me kontroll më të "
-"zgjeruar se sa shndërrimet."
+"Animacionet CSS3 ju lejojnë të ndryshoni vlera vetish në funksion të kohës, "
+"të krijoni animacione të dukjes ose pozicionit të elementëve, pa ose me "
+"minimum JavaScript-i, dhe me kontroll më të zgjeruar se sa shndërrimet."
 
 #: kuma/demos/__init__.py:40
 msgid ""
-"CSS3 Animations are a new feature of modern browsers like Firefox, which add even more flexibility and control to the style and experience of the Web. CSS3 Animations let you change property values "
-"over time with no or minimal JavaScript, and with greater control than CSS Transitions. Go beyond static properties to animate the appearance and positions of HTML elements. You can achieve these "
-"effects without Flash or Silverlight, to make creative dynamic interfaces and engaging animations with CSS3."
+"CSS3 Animations are a new feature of modern browsers like Firefox, which add"
+" even more flexibility and control to the style and experience of the Web. "
+"CSS3 Animations let you change property values over time with no or minimal "
+"JavaScript, and with greater control than CSS Transitions. Go beyond static "
+"properties to animate the appearance and positions of HTML elements. You can"
+" achieve these effects without Flash or Silverlight, to make creative "
+"dynamic interfaces and engaging animations with CSS3."
 msgstr ""
-"Animacionet CSS3 janë një veçori e re e shfletuesve modernë, Firefox-i për shembull, që i shtojnë stilit dhe përmbajtjes së Web-it edhe më tepër zhdërvjelltësi. Animacionet CSS3 ju lejojnë të "
-"ndryshoni vlera vetish në funksion të kohës, pa ose me minimum JavaScript-i, dhe me kontroll më të zgjeruar se sa Shndërrimet CSS. Tejkaloni vetitë statike, që të krijoni animacione të dukjes ose "
-"pozicionit të elementëve HTML. Mund t’i krijoni këto efekte pa Flash ose Silverlight, duke realizuar kështu me CSS3 ndërfaqe dinamike dhe animacione tërheqëse."
+"Animacionet CSS3 janë një veçori e re e shfletuesve modernë, Firefox-i për "
+"shembull, që i shtojnë stilit dhe përmbajtjes së Web-it edhe më tepër "
+"zhdërvjelltësi. Animacionet CSS3 ju lejojnë të ndryshoni vlera vetish në "
+"funksion të kohës, pa ose me minimum JavaScript-i, dhe me kontroll më të "
+"zgjeruar se sa Shndërrimet CSS. Tejkaloni vetitë statike, që të krijoni "
+"animacione të dukjes ose pozicionit të elementëve HTML. Mund t’i krijoni "
+"këto efekte pa Flash ose Silverlight, duke realizuar kështu me CSS3 ndërfaqe"
+" dinamike dhe animacione tërheqëse."
 
 #: kuma/demos/__init__.py:43
 msgid "July 2011 Dev Derby Challenge - HTML5 <video>"
@@ -684,8 +790,12 @@ msgid "July 2011"
 msgstr "Korrik 2011"
 
 #: kuma/demos/__init__.py:46 kuma/demos/__init__.py:47
-msgid "The HTML5 <video> element lets you embed and control video media directly in web pages, without resorting to plug-ins."
-msgstr "Elementi HTML5 <video> ju lejon të trupëzoni dhe kontrolloni video drejt e në faqe web, pa qenë nevoja për shtojca."
+msgid ""
+"The HTML5 <video> element lets you embed and control video media directly in"
+" web pages, without resorting to plug-ins."
+msgstr ""
+"Elementi HTML5 <video> ju lejon të trupëzoni dhe kontrolloni video drejt e "
+"në faqe web, pa qenë nevoja për shtojca."
 
 #: kuma/demos/__init__.py:50
 msgid "August 2011 Dev Derby Challenge - History API"
@@ -700,8 +810,13 @@ msgid "August 2011"
 msgstr "Gusht 2011"
 
 #: kuma/demos/__init__.py:53 kuma/demos/__init__.py:54
-msgid "The History API in modern browsers enables live changes to the document without breaking the back button and allows apps to be bookmarked."
-msgstr "API për Historikun, në shfletuesit modernë lejon ndryshime të drejtpërdrejta te dokumenti pa nxjerrë jashtë loje butonin Mbrapsht dhe lejon faqeruajtjen e aplikacioneve."
+msgid ""
+"The History API in modern browsers enables live changes to the document "
+"without breaking the back button and allows apps to be bookmarked."
+msgstr ""
+"API për Historikun, në shfletuesit modernë lejon ndryshime të drejtpërdrejta"
+" te dokumenti pa nxjerrë jashtë loje butonin Mbrapsht dhe lejon faqeruajtjen"
+" e aplikacioneve."
 
 #: kuma/demos/__init__.py:57
 msgid "September 2011 Dev Derby Challenge - Geolocation"
@@ -715,11 +830,16 @@ msgstr "Gjeovendëzim"
 msgid "September 2011"
 msgstr "Shtator 2011"
 
-#: kuma/demos/__init__.py:60 kuma/demos/__init__.py:61 kuma/demos/__init__.py:144 kuma/demos/__init__.py:145
-msgid "With Geolocation, you can get the user's physical location (with permission) and use it to enhance the browsing experience or enable advanced location-aware features."
+#: kuma/demos/__init__.py:60 kuma/demos/__init__.py:61
+#: kuma/demos/__init__.py:144 kuma/demos/__init__.py:145
+msgid ""
+"With Geolocation, you can get the user's physical location (with permission)"
+" and use it to enhance the browsing experience or enable advanced location-"
+"aware features."
 msgstr ""
-"Me Gjeovendëzimin, mund të mësoni vendndodhjen fizike të përdoruesit (me lejen e tij) dhe ta përdorni atë për të zgjeruar shfletimin e tij ose për të aktivizuar veçori të mëtejshme me bazë "
-"vendndodhjen."
+"Me Gjeovendëzimin, mund të mësoni vendndodhjen fizike të përdoruesit (me "
+"lejen e tij) dhe ta përdorni atë për të zgjeruar shfletimin e tij ose për të"
+" aktivizuar veçori të mëtejshme me bazë vendndodhjen."
 
 #: kuma/demos/__init__.py:64
 msgid "October 2011 Dev Derby Challenge - CSS Media Queries"
@@ -734,8 +854,14 @@ msgid "October 2011"
 msgstr "Tetor 2011"
 
 #: kuma/demos/__init__.py:67 kuma/demos/__init__.py:68
-msgid "CSS Media Queries allow Web developers to create responsive Web designs, tailoring the user experience for a range of screen sizes, including desktops, tablets, and mobiles."
-msgstr "Kërkesat Media CSS u lejojnë zhvilluesve të krijojnë skema grafike Web reaguese, duke ua përshtatur përdoruesve punimin për një gamë madhësish ekrani, përfshi desktopë, tablete, dhe celularë."
+msgid ""
+"CSS Media Queries allow Web developers to create responsive Web designs, "
+"tailoring the user experience for a range of screen sizes, including "
+"desktops, tablets, and mobiles."
+msgstr ""
+"Kërkesat Media CSS u lejojnë zhvilluesve të krijojnë skema grafike Web "
+"reaguese, duke ua përshtatur përdoruesve punimin për një gamë madhësish "
+"ekrani, përfshi desktopë, tablete, dhe celularë."
 
 #: kuma/demos/__init__.py:71
 msgid "November 2011 Dev Derby Challenge - Canvas"
@@ -747,11 +873,15 @@ msgstr "Nëntor 2011"
 
 #: kuma/demos/__init__.py:74 kuma/demos/__init__.py:75
 msgid ""
-"Canvas lets you paint the Web using JavaScript to render 2D shapes, bitmapped images, and advanced graphical effects. Each <canvas> element provides a graphics context with its own state and "
-"methods that make it easy to control and draw in."
+"Canvas lets you paint the Web using JavaScript to render 2D shapes, "
+"bitmapped images, and advanced graphical effects. Each <canvas> element "
+"provides a graphics context with its own state and methods that make it easy"
+" to control and draw in."
 msgstr ""
-"Canvas-a ju lejon të vizatoni në Web duke përdorur JavaScript për të përftuar forma 2D, figura bitmap, dhe efekte grafike të thelluara. Çdo element <canvas> ofron një kontekst grafik me gjendjen "
-"dhe metodat e veta, çka i bën të lehtë për t’u kontrolluar dhe përdorur për vizatime."
+"Canvas-a ju lejon të vizatoni në Web duke përdorur JavaScript për të "
+"përftuar forma 2D, figura bitmap, dhe efekte grafike të thelluara. Çdo "
+"element <canvas> ofron një kontekst grafik me gjendjen dhe metodat e veta, "
+"çka i bën të lehtë për t’u kontrolluar dhe përdorur për vizatime."
 
 #: kuma/demos/__init__.py:78
 msgid "December 2011 Dev Derby Challenge - IndexedDB"
@@ -766,8 +896,13 @@ msgid "December 2011"
 msgstr "Dhjetor 2011"
 
 #: kuma/demos/__init__.py:81 kuma/demos/__init__.py:82
-msgid "IndexedDB lets web applications store significant amounts of structured data locally, for faster access, online or offline."
-msgstr "IndexedDB u lejon zbatimeve web të depozitojnë lokalisht sasi të konsiderueshme të dhënash të strukturuara, për përdorim më të shpejtë, në internet ose jashtë tij."
+msgid ""
+"IndexedDB lets web applications store significant amounts of structured data"
+" locally, for faster access, online or offline."
+msgstr ""
+"IndexedDB u lejon zbatimeve web të depozitojnë lokalisht sasi të "
+"konsiderueshme të dhënash të strukturuara, për përdorim më të shpejtë, në "
+"internet ose jashtë tij."
 
 #: kuma/demos/__init__.py:85
 msgid "January 2012 Dev Derby Challenge - Orientation"
@@ -782,8 +917,12 @@ msgid "January 2012"
 msgstr "Janar 2012"
 
 #: kuma/demos/__init__.py:88 kuma/demos/__init__.py:89
-msgid "Orientation features in HTML5 access the motion and orientation data of devices with accelerometers."
-msgstr "Veçoritë e orientimit në HTML5 shfrytëzojnë të dhëna lëvizjesh dhe orientimi prej pajisjesh me akselerometra."
+msgid ""
+"Orientation features in HTML5 access the motion and orientation data of "
+"devices with accelerometers."
+msgstr ""
+"Veçoritë e orientimit në HTML5 shfrytëzojnë të dhëna lëvizjesh dhe orientimi"
+" prej pajisjesh me akselerometra."
 
 #: kuma/demos/__init__.py:92
 msgid "February 2012 Dev Derby Challenge - Touch Events"
@@ -798,8 +937,12 @@ msgid "February 2012"
 msgstr "Shkurt 2012"
 
 #: kuma/demos/__init__.py:95 kuma/demos/__init__.py:96
-msgid "Touch Events help you make websites and applications more engaging by responding appropriately when users interact with touch screens."
-msgstr "Aktet e Prekjes ju ndihmojnë t’i bëni sajtet dhe aplikacionet më tërheqës, duke reaguar si duhet, kur përdoruesi ndërvepron me ekrane me prekje."
+msgid ""
+"Touch Events help you make websites and applications more engaging by "
+"responding appropriately when users interact with touch screens."
+msgstr ""
+"Aktet e Prekjes ju ndihmojnë t’i bëni sajtet dhe aplikacionet më tërheqës, "
+"duke reaguar si duhet, kur përdoruesi ndërvepron me ekrane me prekje."
 
 #: kuma/demos/__init__.py:99
 msgid "March 2012 Dev Derby Challenge - CSS 3D Transforms"
@@ -814,8 +957,12 @@ msgid "March 2012"
 msgstr "Mars 2012"
 
 #: kuma/demos/__init__.py:102 kuma/demos/__init__.py:103
-msgid "CSS 3D Transforms extends CSS Transforms to allow elements rendered by CSS to be transformed in three-dimensional space."
-msgstr "Shndërrimet CSS 3D zgjerojnë Shndërrimet CSS, për t’u lejuar elementeve të vizatuar nga CSS-ja të shndërrohen në hapësira trepërmasore."
+msgid ""
+"CSS 3D Transforms extends CSS Transforms to allow elements rendered by CSS "
+"to be transformed in three-dimensional space."
+msgstr ""
+"Shndërrimet CSS 3D zgjerojnë Shndërrimet CSS, për t’u lejuar elementeve të "
+"vizatuar nga CSS-ja të shndërrohen në hapësira trepërmasore."
 
 #: kuma/demos/__init__.py:106
 msgid "April 2012 Dev Derby Challenge - Audio"
@@ -830,8 +977,12 @@ msgid "April 2012"
 msgstr "Prill 2012"
 
 #: kuma/demos/__init__.py:109 kuma/demos/__init__.py:110
-msgid "The HTML5 audio element lets you embed sound in webpages without requiring your users to rely on plug-ins."
-msgstr "Elementet audio HTML5 ju lejojnë të trupëzoni tinguj në faqe web, pa qenë nevoja që përdoruesi të përdorë shtojca për dëgjimin e tyre."
+msgid ""
+"The HTML5 audio element lets you embed sound in webpages without requiring "
+"your users to rely on plug-ins."
+msgstr ""
+"Elementet audio HTML5 ju lejojnë të trupëzoni tinguj në faqe web, pa qenë "
+"nevoja që përdoruesi të përdorë shtojca për dëgjimin e tyre."
 
 #: kuma/demos/__init__.py:113
 msgid "May 2012 Dev Derby Challenge - WebSockets API"
@@ -846,10 +997,14 @@ msgid "May 2012"
 msgstr "Maj 2012"
 
 #: kuma/demos/__init__.py:116 kuma/demos/__init__.py:117
-msgid "With the Websocket API and protocol, you can open a two-way channel between the browser and a server, for scalable and real-time data flow. No more server polling!"
+msgid ""
+"With the Websocket API and protocol, you can open a two-way channel between "
+"the browser and a server, for scalable and real-time data flow. No more "
+"server polling!"
 msgstr ""
-"Me API-n dhe protokollin Websocket, mund të hapni një kanal dykahësh mes shfletuesit dhe një shërbyesi, për rrjedha të atypëratyshme të dhënash, me madhësi të ndryshueshme. S’ka më nevojë për "
-"vjelje që prej shërbyesit!"
+"Me API-n dhe protokollin Websocket, mund të hapni një kanal dykahësh mes "
+"shfletuesit dhe një shërbyesi, për rrjedha të atypëratyshme të dhënash, me "
+"madhësi të ndryshueshme. S’ka më nevojë për vjelje që prej shërbyesit!"
 
 #: kuma/demos/__init__.py:120
 msgid "June 2012 Dev Derby Challenge - WebGL"
@@ -859,9 +1014,14 @@ msgstr "Gara Dev Derby e Qershorit 2012 - WebGL"
 msgid "June 2012"
 msgstr "Qershor 2012"
 
-#: kuma/demos/__init__.py:123 kuma/demos/__init__.py:124 kuma/demos/__init__.py:211 kuma/demos/__init__.py:212
-msgid "WebGL brings the power of OpenGL, for creating interactive 3D graphics, to the Web, with no plug-ins required."
-msgstr "WebGL i sjell Web-it fuqinë e OpenGL-së, për krijimin grafike 3D, pa patur nevojë për shtojca."
+#: kuma/demos/__init__.py:123 kuma/demos/__init__.py:124
+#: kuma/demos/__init__.py:211 kuma/demos/__init__.py:212
+msgid ""
+"WebGL brings the power of OpenGL, for creating interactive 3D graphics, to "
+"the Web, with no plug-ins required."
+msgstr ""
+"WebGL i sjell Web-it fuqinë e OpenGL-së, për krijimin grafike 3D, pa patur "
+"nevojë për shtojca."
 
 #: kuma/demos/__init__.py:127
 msgid "July 2012 Dev Derby Challenge - No JavaScript"
@@ -877,11 +1037,16 @@ msgstr "Korrik 2012"
 
 #: kuma/demos/__init__.py:130 kuma/demos/__init__.py:131
 msgid ""
-"Creating rich user experiences for the Web has never been easier. Today's open Web standards put some of the most powerful features right at your fingertips. Animate pages with CSS, validate user "
-"input with HTML, and more. What else can you do without JavaScript?"
+"Creating rich user experiences for the Web has never been easier. Today's "
+"open Web standards put some of the most powerful features right at your "
+"fingertips. Animate pages with CSS, validate user input with HTML, and more."
+" What else can you do without JavaScript?"
 msgstr ""
-"Ofrimi i ndjesive të pasura në Web për përdoruesit s’ka qenë kurrë më i lehtë. Sot, standardet e hapura Web, ju vënë në majë të gishtave disa nga veçoritë më të fuqishme. Krijoni me CSS-në "
-"animacione në faqe, vleftësoni përmes HTML-së input përdoruesi, etj. Ç’mund të bëni tjetër me JavaScript-in?"
+"Ofrimi i ndjesive të pasura në Web për përdoruesit s’ka qenë kurrë më i "
+"lehtë. Sot, standardet e hapura Web, ju vënë në majë të gishtave disa nga "
+"veçoritë më të fuqishme. Krijoni me CSS-në animacione në faqe, vleftësoni "
+"përmes HTML-së input përdoruesi, etj. Ç’mund të bëni tjetër me JavaScript-"
+"in?"
 
 #: kuma/demos/__init__.py:134
 msgid "August 2012 Dev Derby Challenge - Camera API"
@@ -896,8 +1061,14 @@ msgid "August 2012"
 msgstr "Gusht 2012"
 
 #: kuma/demos/__init__.py:137 kuma/demos/__init__.py:138
-msgid "The Camera API lets you access (with permission) the cameras of mobile devices. With the Camera API, users can easily take pictures and upload them to your web page."
-msgstr "API për Kamera ju lejojnë të përdorni (me leje) kamera prej pajisjesh celulare. Me API-n për Kamera, përdoruesit munden lehtësisht të bëjnë foto dhe t’i ngarkojnë te faqja juaj web."
+msgid ""
+"The Camera API lets you access (with permission) the cameras of mobile "
+"devices. With the Camera API, users can easily take pictures and upload them"
+" to your web page."
+msgstr ""
+"API për Kamera ju lejojnë të përdorni (me leje) kamera prej pajisjesh "
+"celulare. Me API-n për Kamera, përdoruesit munden lehtësisht të bëjnë foto "
+"dhe t’i ngarkojnë te faqja juaj web."
 
 #: kuma/demos/__init__.py:141
 msgid "September 2012 Dev Derby Challenge - Geolocation II"
@@ -925,11 +1096,14 @@ msgstr "Tetor 2012"
 
 #: kuma/demos/__init__.py:151 kuma/demos/__init__.py:152
 msgid ""
-"CSS Media Queries are now a common tool for responsive, mobile-first web design. They are now even a W3C Recommendation! They can tell you a lot more about a display than just its width. What can "
-"you do with Media Queries?"
+"CSS Media Queries are now a common tool for responsive, mobile-first web "
+"design. They are now even a W3C Recommendation! They can tell you a lot more"
+" about a display than just its width. What can you do with Media Queries?"
 msgstr ""
-"Kërkesa Media CSS janë tashmë një mjet i rëndomtë për hartime grafike web reaguese, për celularët më tepër. Tashmë janë edhe një nga Rekomandimet e W3C-së! Mund t’ju tregojnë për ekranin shumë më "
-"tepër gjëra se sa thjesht gjerësia. Ç’mund të bëni me Kërkesa Media?"
+"Kërkesa Media CSS janë tashmë një mjet i rëndomtë për hartime grafike web "
+"reaguese, për celularët më tepër. Tashmë janë edhe një nga Rekomandimet e "
+"W3C-së! Mund t’ju tregojnë për ekranin shumë më tepër gjëra se sa thjesht "
+"gjerësia. Ç’mund të bëni me Kërkesa Media?"
 
 #: kuma/demos/__init__.py:155
 msgid "November 2012 Dev Derby Challenge - Fullscreen API"
@@ -944,10 +1118,15 @@ msgid "November 2012"
 msgstr "Nëntor 2012"
 
 #: kuma/demos/__init__.py:158 kuma/demos/__init__.py:159
-msgid "With the Fullscreen API, you can escape the confines of the browser window. You can even detect full screen state changes and style full screen pages specially. Talk about immersive!"
+msgid ""
+"With the Fullscreen API, you can escape the confines of the browser window. "
+"You can even detect full screen state changes and style full screen pages "
+"specially. Talk about immersive!"
 msgstr ""
-"Me API-n për Ekran të Plotë, mund t’u shpëtoni kufizimeve të dritares së shfletuesit. Mundeni madje të zbuloni praninë e ekranit të plotë dhe të ofroni faqe sa krejt ekrani, posaçërisht për raste "
-"të tilla. Vërtet ngërthyese!"
+"Me API-n për Ekran të Plotë, mund t’u shpëtoni kufizimeve të dritares së "
+"shfletuesit. Mundeni madje të zbuloni praninë e ekranit të plotë dhe të "
+"ofroni faqe sa krejt ekrani, posaçërisht për raste të tilla. Vërtet "
+"ngërthyese!"
 
 #: kuma/demos/__init__.py:162
 msgid "December 2012 Dev Derby Challenge - Offline"
@@ -963,11 +1142,15 @@ msgstr "Dhjetor 2012"
 
 #: kuma/demos/__init__.py:165 kuma/demos/__init__.py:166
 msgid ""
-"With the maturing offline capabilities of the open Web, you can build apps that work with or without an Internet connection. With offline technologies, you can better support travelers and mobile "
-"users, improve performance, and more."
+"With the maturing offline capabilities of the open Web, you can build apps "
+"that work with or without an Internet connection. With offline technologies,"
+" you can better support travelers and mobile users, improve performance, and"
+" more."
 msgstr ""
-"Me pjekjen e vazhdueshme të aftësive të Web-it të hapur për punim jashtë Internetit, mund të krijoni aplikacione që punojnë me ose pa lidhje Internet. Me teknologjitë <em>offline</em>, mund t’u "
-"shërbeni më mirë përdoruesve në lëvizje dhe atyre të celularit, të përmirësoni punimin, etj."
+"Me pjekjen e vazhdueshme të aftësive të Web-it të hapur për punim jashtë "
+"Internetit, mund të krijoni aplikacione që punojnë me ose pa lidhje "
+"Internet. Me teknologjitë <em>offline</em>, mund t’u shërbeni më mirë "
+"përdoruesve në lëvizje dhe atyre të celularit, të përmirësoni punimin, etj."
 
 #: kuma/demos/__init__.py:169
 msgid "January 2013 Dev Derby Challenge - Drag and Drop"
@@ -982,8 +1165,13 @@ msgid "January 2013"
 msgstr "Janar 2013"
 
 #: kuma/demos/__init__.py:172 kuma/demos/__init__.py:173
-msgid "The Drag and Drop API brings an age-old interaction to the Web, making rich, natural, and familiar user experiences possible."
-msgstr "API për Merr dhe Vër sjell në Web një mënyrë ndërveprimi të regjur ndër vite, duke bërë të mundur për përdoruesit funksione të pasura, natyrorë dhe familjarë."
+msgid ""
+"The Drag and Drop API brings an age-old interaction to the Web, making rich,"
+" natural, and familiar user experiences possible."
+msgstr ""
+"API për Merr dhe Vër sjell në Web një mënyrë ndërveprimi të regjur ndër "
+"vite, duke bërë të mundur për përdoruesit funksione të pasura, natyrorë dhe "
+"familjarë."
 
 #: kuma/demos/__init__.py:176
 msgid "February 2013 Dev Derby Challenge - Multi-touch"
@@ -999,11 +1187,15 @@ msgstr "Shkurt 2013"
 
 #: kuma/demos/__init__.py:179 kuma/demos/__init__.py:180
 msgid ""
-"The Touch Events API lets you track multiple touches at the same time on devices that support them. Build complex games, support pinch-to-zoom and more. By using multi-touch, your app can respond "
-"to all the interactions users have come to expect."
+"The Touch Events API lets you track multiple touches at the same time on "
+"devices that support them. Build complex games, support pinch-to-zoom and "
+"more. By using multi-touch, your app can respond to all the interactions "
+"users have come to expect."
 msgstr ""
-"API për Akte Prekjeje ju lejon të ndiqni disa prekje njëherësh, në pajisje që mbulojnë diçka të tillë. Krijoni lojëra komplekse, mbuloni efekte pickoni-që-të-zmadhoni, etj. Duke përdorur "
-"shumëprekjen, aplikacioni juaj mund t’u përgjigjet krejt ndërveprimeve që presin përdoruesit."
+"API për Akte Prekjeje ju lejon të ndiqni disa prekje njëherësh, në pajisje "
+"që mbulojnë diçka të tillë. Krijoni lojëra komplekse, mbuloni efekte "
+"pickoni-që-të-zmadhoni, etj. Duke përdorur shumëprekjen, aplikacioni juaj "
+"mund t’u përgjigjet krejt ndërveprimeve që presin përdoruesit."
 
 #: kuma/demos/__init__.py:183
 msgid "March 2013 Dev Derby Challenge - Mobile"
@@ -1014,8 +1206,14 @@ msgid "March 2013"
 msgstr "Mars 2013"
 
 #: kuma/demos/__init__.py:186 kuma/demos/__init__.py:187
-msgid "The mobile Web is becoming more important every day. This time, the only limit is your creativity. What amazing experiences can you build for users on the go?"
-msgstr "Web-i në celular po bëhet çdo ditë e më i rëndësishëm. Tashmë, kufiri i vetëm është fryma juaj krijuese. Ç’gjëra mahnitëse mund të krijoni për përdoruesit në lëvizje?"
+msgid ""
+"The mobile Web is becoming more important every day. This time, the only "
+"limit is your creativity. What amazing experiences can you build for users "
+"on the go?"
+msgstr ""
+"Web-i në celular po bëhet çdo ditë e më i rëndësishëm. Tashmë, kufiri i "
+"vetëm është fryma juaj krijuese. Ç’gjëra mahnitëse mund të krijoni për "
+"përdoruesit në lëvizje?"
 
 #: kuma/demos/__init__.py:190
 msgid "April 2013 Dev Derby Challenge - Web Workers"
@@ -1031,10 +1229,13 @@ msgstr "Prill 2013"
 
 #: kuma/demos/__init__.py:193 kuma/demos/__init__.py:194
 msgid ""
-"Web Workers make it easy for you to run scripts in the background. By using Web Workers, you can create dazzling user interfaces that are not hindered by even the most computationally-intensive "
-"tasks."
+"Web Workers make it easy for you to run scripts in the background. By using "
+"Web Workers, you can create dazzling user interfaces that are not hindered "
+"by even the most computationally-intensive tasks."
 msgstr ""
-"Web Workers ua bën të lehtë xhirimin në prapaskenë të programtheve. Duke përdorur Web Workers, mund të krijoni ndërfaqe përdoruesi mahnitëse, që s’ndikohen as nga veprimet kompjuterike më intensive."
+"Web Workers ua bën të lehtë xhirimin në prapaskenë të programtheve. Duke "
+"përdorur Web Workers, mund të krijoni ndërfaqe përdoruesi mahnitëse, që "
+"s’ndikohen as nga veprimet kompjuterike më intensive."
 
 #: kuma/demos/__init__.py:197
 msgid "May 2013 Dev Derby Challenge - getUserMedia"
@@ -1058,9 +1259,13 @@ msgstr "Veprim!"
 
 #: kuma/demos/__init__.py:202 kuma/demos/__init__.py:203
 msgid ""
-"The getUserMedia function lets you access (with permission) the cameras and microphones of your users. No plugins needed! What can you do once you have this media? The possibilities are endless."
+"The getUserMedia function lets you access (with permission) the cameras and "
+"microphones of your users. No plugins needed! What can you do once you have "
+"this media? The possibilities are endless."
 msgstr ""
-"Funksioni getUserMedia ju lejon përdorimin (me leje) të kamerave dhe mikrofonëve të përdoruesve tuaj. Pa patur nevojë për shtojca! Ç’mund të bëni, kur keni hyrje në to? Mundësitë janë të pafundme."
+"Funksioni getUserMedia ju lejon përdorimin (me leje) të kamerave dhe "
+"mikrofonëve të përdoruesve tuaj. Pa patur nevojë për shtojca! Ç’mund të "
+"bëni, kur keni hyrje në to? Mundësitë janë të pafundme."
 
 #: kuma/demos/__init__.py:206
 msgid "June 2013 Dev Derby Challenge - WebGL II"
@@ -1103,26 +1308,51 @@ msgid "File found"
 msgstr "U gjet kartelë"
 
 #: kuma/demos/__init__.py:220 kuma/demos/__init__.py:221
-msgid "The File API lets you read the contents of files submitted by your users, making natural and familiar data operations possible."
-msgstr "API për Kartelat ju lejon të lexoni lëndën e kartelave të parashtruara nga përdoruesit tuaj, duke bërë të mundur kështu veprime natyrore dhe familjare."
+msgid ""
+"The File API lets you read the contents of files submitted by your users, "
+"making natural and familiar data operations possible."
+msgstr ""
+"API për Kartelat ju lejon të lexoni lëndën e kartelave të parashtruara nga "
+"përdoruesit tuaj, duke bërë të mundur kështu veprime natyrore dhe familjare."
 
 #: kuma/demos/__init__.py:226
-msgid "Mozilla's Audio Data API extends the current HTML5 API and allows web developers to read and write raw audio data."
-msgstr "API i Mozilla-s për Të dhëna Audio zgjeron API-n përkatës HTML5 dhe u lejon zhvilluesve web të lexojnë dhe shkruajnë të dhëna audio të papërpunuara."
+msgid ""
+"Mozilla's Audio Data API extends the current HTML5 API and allows web "
+"developers to read and write raw audio data."
+msgstr ""
+"API i Mozilla-s për Të dhëna Audio zgjeron API-n përkatës HTML5 dhe u lejon "
+"zhvilluesve web të lexojnë dhe shkruajnë të dhëna audio të papërpunuara."
 
-#: kuma/demos/__init__.py:228 kuma/demos/__init__.py:236 kuma/demos/__init__.py:244 kuma/demos/__init__.py:252 kuma/demos/__init__.py:259 kuma/demos/__init__.py:266 kuma/demos/__init__.py:274
-#: kuma/demos/__init__.py:282 kuma/demos/__init__.py:290 kuma/demos/__init__.py:298 kuma/demos/__init__.py:306 kuma/demos/__init__.py:314 kuma/demos/__init__.py:322 kuma/demos/__init__.py:330
-#: kuma/demos/__init__.py:338 kuma/demos/__init__.py:346 kuma/demos/__init__.py:354 kuma/demos/__init__.py:362 kuma/demos/__init__.py:370 kuma/demos/__init__.py:378 kuma/demos/__init__.py:386
+#: kuma/demos/__init__.py:228 kuma/demos/__init__.py:236
+#: kuma/demos/__init__.py:244 kuma/demos/__init__.py:252
+#: kuma/demos/__init__.py:259 kuma/demos/__init__.py:266
+#: kuma/demos/__init__.py:274 kuma/demos/__init__.py:282
+#: kuma/demos/__init__.py:290 kuma/demos/__init__.py:298
+#: kuma/demos/__init__.py:306 kuma/demos/__init__.py:314
+#: kuma/demos/__init__.py:322 kuma/demos/__init__.py:330
+#: kuma/demos/__init__.py:338 kuma/demos/__init__.py:346
+#: kuma/demos/__init__.py:354 kuma/demos/__init__.py:362
+#: kuma/demos/__init__.py:370 kuma/demos/__init__.py:378
+#: kuma/demos/__init__.py:386
 msgid "MDN Documentation"
 msgstr "Dokumentim MDN"
 
 #: kuma/demos/__init__.py:228
-msgid "https://developer.mozilla.org/en-US/docs/Introducing_the_Audio_API_Extension"
-msgstr "https://developer.mozilla.org/en-US/docs/Introducing_the_Audio_API_Extension"
+msgid ""
+"https://developer.mozilla.org/en-US/docs/Introducing_the_Audio_API_Extension"
+msgstr ""
+"https://developer.mozilla.org/en-US/docs/Introducing_the_Audio_API_Extension"
 
-#: kuma/demos/__init__.py:229 kuma/demos/__init__.py:237 kuma/demos/__init__.py:245 kuma/demos/__init__.py:267 kuma/demos/__init__.py:275 kuma/demos/__init__.py:283 kuma/demos/__init__.py:291
-#: kuma/demos/__init__.py:299 kuma/demos/__init__.py:307 kuma/demos/__init__.py:315 kuma/demos/__init__.py:323 kuma/demos/__init__.py:331 kuma/demos/__init__.py:339 kuma/demos/__init__.py:347
-#: kuma/demos/__init__.py:355 kuma/demos/__init__.py:363 kuma/demos/__init__.py:371 kuma/demos/__init__.py:379 kuma/demos/__init__.py:387
+#: kuma/demos/__init__.py:229 kuma/demos/__init__.py:237
+#: kuma/demos/__init__.py:245 kuma/demos/__init__.py:267
+#: kuma/demos/__init__.py:275 kuma/demos/__init__.py:283
+#: kuma/demos/__init__.py:291 kuma/demos/__init__.py:299
+#: kuma/demos/__init__.py:307 kuma/demos/__init__.py:315
+#: kuma/demos/__init__.py:323 kuma/demos/__init__.py:331
+#: kuma/demos/__init__.py:339 kuma/demos/__init__.py:347
+#: kuma/demos/__init__.py:355 kuma/demos/__init__.py:363
+#: kuma/demos/__init__.py:371 kuma/demos/__init__.py:379
+#: kuma/demos/__init__.py:387
 msgid "Wikipedia Article"
 msgstr "Artikull Wikipedia"
 
@@ -1130,9 +1360,16 @@ msgstr "Artikull Wikipedia"
 msgid "http://en.wikipedia.org/wiki/HTML5_audio"
 msgstr "http://en.wikipedia.org/wiki/HTML5_audio"
 
-#: kuma/demos/__init__.py:230 kuma/demos/__init__.py:238 kuma/demos/__init__.py:246 kuma/demos/__init__.py:253 kuma/demos/__init__.py:260 kuma/demos/__init__.py:268 kuma/demos/__init__.py:276
-#: kuma/demos/__init__.py:284 kuma/demos/__init__.py:300 kuma/demos/__init__.py:308 kuma/demos/__init__.py:316 kuma/demos/__init__.py:324 kuma/demos/__init__.py:332 kuma/demos/__init__.py:340
-#: kuma/demos/__init__.py:348 kuma/demos/__init__.py:364 kuma/demos/__init__.py:372 kuma/demos/__init__.py:380 kuma/demos/__init__.py:388
+#: kuma/demos/__init__.py:230 kuma/demos/__init__.py:238
+#: kuma/demos/__init__.py:246 kuma/demos/__init__.py:253
+#: kuma/demos/__init__.py:260 kuma/demos/__init__.py:268
+#: kuma/demos/__init__.py:276 kuma/demos/__init__.py:284
+#: kuma/demos/__init__.py:300 kuma/demos/__init__.py:308
+#: kuma/demos/__init__.py:316 kuma/demos/__init__.py:324
+#: kuma/demos/__init__.py:332 kuma/demos/__init__.py:340
+#: kuma/demos/__init__.py:348 kuma/demos/__init__.py:364
+#: kuma/demos/__init__.py:372 kuma/demos/__init__.py:380
+#: kuma/demos/__init__.py:388
 msgid "W3C Spec"
 msgstr "Specifikime W3C"
 
@@ -1141,8 +1378,12 @@ msgid "http://www.w3.org/TR/html5/embedded-content-0.html#the-audio-element"
 msgstr "http://www.w3.org/TR/html5/embedded-content-0.html#the-audio-element"
 
 #: kuma/demos/__init__.py:234
-msgid "The HTML5 canvas element allows you to display scriptable renderings of 2D shapes and bitmap images."
-msgstr "Elementët kanavacë HTML5 ju lejojnë të shfaqni përftime të skriptueshme formash 2D dhe figura bitmap."
+msgid ""
+"The HTML5 canvas element allows you to display scriptable renderings of 2D "
+"shapes and bitmap images."
+msgstr ""
+"Elementët kanavacë HTML5 ju lejojnë të shfaqni përftime të skriptueshme "
+"formash 2D dhe figura bitmap."
 
 #: kuma/demos/__init__.py:236
 msgid "https://developer.mozilla.org/en-US/docs/HTML/Canvas"
@@ -1162,10 +1403,13 @@ msgstr "CSS3"
 
 #: kuma/demos/__init__.py:242
 msgid ""
-"Cascading Style Sheets level 3 (CSS3) provide serveral new features and properties to enhance the formatting and look of documents written in different kinds of markup languages like HTML or XML."
+"Cascading Style Sheets level 3 (CSS3) provide serveral new features and "
+"properties to enhance the formatting and look of documents written in "
+"different kinds of markup languages like HTML or XML."
 msgstr ""
-"Cascading Style Sheets të nivelit 3 (CSS3) ofron disa veçori dhe veti të reja për thellim në formatime dhe pamje të dokumenteve të shkruar në lloje të ndryshme gjuhësh markup, të tilla si HTML ose "
-"XML."
+"Cascading Style Sheets të nivelit 3 (CSS3) ofron disa veçori dhe veti të "
+"reja për thellim në formatime dhe pamje të dokumenteve të shkruar në lloje "
+"të ndryshme gjuhësh markup, të tilla si HTML ose XML."
 
 #: kuma/demos/__init__.py:244
 msgid "https://developer.mozilla.org/en-US/docs/Web/CSS"
@@ -1184,12 +1428,18 @@ msgid "Device"
 msgstr "Pajisje"
 
 #: kuma/demos/__init__.py:250
-msgid "Media queries and orientation events let authors adjust their layout on hand-held devices such as mobile phones."
-msgstr "Kërkesat media dhe aktet e orientimit u lejojnë autorëve t’ua përshtatin hartimin grafik pajisjeve celulare."
+msgid ""
+"Media queries and orientation events let authors adjust their layout on "
+"hand-held devices such as mobile phones."
+msgstr ""
+"Kërkesat media dhe aktet e orientimit u lejojnë autorëve t’ua përshtatin "
+"hartimin grafik pajisjeve celulare."
 
 #: kuma/demos/__init__.py:252
-msgid "https://developer.mozilla.org/en-US/docs/WebAPI/Detecting_device_orientation"
-msgstr "https://developer.mozilla.org/en-US/docs/WebAPI/Detecting_device_orientation"
+msgid ""
+"https://developer.mozilla.org/en-US/docs/WebAPI/Detecting_device_orientation"
+msgstr ""
+"https://developer.mozilla.org/en-US/docs/WebAPI/Detecting_device_orientation"
 
 #: kuma/demos/__init__.py:253
 msgid "http://www.w3.org/TR/css3-mediaqueries/"
@@ -1200,12 +1450,18 @@ msgid "Files"
 msgstr "Kartela"
 
 #: kuma/demos/__init__.py:257
-msgid "The File API allows web developers to use file objects in web applications, as well as selecting and accessing their data."
-msgstr "API për Kartela u lejon zhvilluesve të përdorin objekte kartelash në aplikacione, të tilla si përzgjedhje dhe hyrje në të dhënat e tyre."
+msgid ""
+"The File API allows web developers to use file objects in web applications, "
+"as well as selecting and accessing their data."
+msgstr ""
+"API për Kartela u lejon zhvilluesve të përdorin objekte kartelash në "
+"aplikacione, të tilla si përzgjedhje dhe hyrje në të dhënat e tyre."
 
 #: kuma/demos/__init__.py:259
-msgid "https://developer.mozilla.org/en-US/docs/using_files_from_web_applications"
-msgstr "https://developer.mozilla.org/en-US/docs/using_files_from_web_applications"
+msgid ""
+"https://developer.mozilla.org/en-US/docs/using_files_from_web_applications"
+msgstr ""
+"https://developer.mozilla.org/en-US/docs/using_files_from_web_applications"
 
 #: kuma/demos/__init__.py:260
 msgid "http://www.w3.org/TR/FileAPI/"
@@ -1216,9 +1472,14 @@ msgid "Fonts & Type"
 msgstr "Shkronja & Shtypje"
 
 #: kuma/demos/__init__.py:264
-msgid "The CSS3-Font specification contains enhanced features for fonts and typography like embedding own fonts via @font-face or controlling OpenType font features directly via CSS."
+msgid ""
+"The CSS3-Font specification contains enhanced features for fonts and "
+"typography like embedding own fonts via @font-face or controlling OpenType "
+"font features directly via CSS."
 msgstr ""
-"Specifikimet CSS3-Font përmbajnë veçori të zgjeruara për shkronja dhe tipografi, të tilla si trupëzim shkronjash përmes @font-face ose kontroll veçorish shkronjash OpenType drejt e nga CSS-ja."
+"Specifikimet CSS3-Font përmbajnë veçori të zgjeruara për shkronja dhe "
+"tipografi, të tilla si trupëzim shkronjash përmes @font-face ose kontroll "
+"veçorish shkronjash OpenType drejt e nga CSS-ja."
 
 #: kuma/demos/__init__.py:266
 msgid "https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face"
@@ -1237,10 +1498,14 @@ msgid "Forms"
 msgstr "Formularë"
 
 #: kuma/demos/__init__.py:272
-msgid "Form elements and attributes in HTML5 provide a greater degree of semantic mark-up than HTML4 and remove a great deal of the need for tedious scripting and styling that was required in HTML4."
+msgid ""
+"Form elements and attributes in HTML5 provide a greater degree of semantic "
+"mark-up than HTML4 and remove a great deal of the need for tedious scripting"
+" and styling that was required in HTML4."
 msgstr ""
-"Elementët dhe atributet e formularëve në HTML5 ofrojnë një shkallë më të lartë mark-up-i semantik se sa HTML4 dhe e ulin mjaft nevojën për skriptime dhe stilizime të mërzitshme siç duhej nën HTML4-"
-"n."
+"Elementët dhe atributet e formularëve në HTML5 ofrojnë një shkallë më të "
+"lartë mark-up-i semantik se sa HTML4 dhe e ulin mjaft nevojën për skriptime "
+"dhe stilizime të mërzitshme siç duhej nën HTML4-n."
 
 #: kuma/demos/__init__.py:274
 msgid "https://developer.mozilla.org/en-US/docs/Web/HTML/Forms_in_HTML"
@@ -1255,8 +1520,12 @@ msgid "http://www.w3.org/TR/html5/forms.html"
 msgstr "http://www.w3.org/TR/html5/forms.html"
 
 #: kuma/demos/__init__.py:280
-msgid "The Geolocation API allows web applications to access the user's geographical location."
-msgstr "API për Gjeovendëzim u lejon aplikacioneve të shfrytëzojnë vendndodhjen gjeografike të përdoruesve."
+msgid ""
+"The Geolocation API allows web applications to access the user's "
+"geographical location."
+msgstr ""
+"API për Gjeovendëzim u lejon aplikacioneve të shfrytëzojnë vendndodhjen "
+"gjeografike të përdoruesve."
 
 #: kuma/demos/__init__.py:282
 msgid "https://developer.mozilla.org/en-US/docs/WebAPI/Using_geolocation"
@@ -1271,8 +1540,14 @@ msgid "http://dev.w3.org/geo/api/spec-source.html"
 msgstr "http://dev.w3.org/geo/api/spec-source.html"
 
 #: kuma/demos/__init__.py:288
-msgid "JavaScript is a lightweight, object-oriented programming language, commonly used for scripting interactive behavior on web pages and in web applications."
-msgstr "JavaScript është një gjuhë programi object-oriented, e peshës së lehtë, e përdorur rëndom për programim ndërveprimesh mes përdoruesit dhe faqesh apo aplikacionesh web."
+msgid ""
+"JavaScript is a lightweight, object-oriented programming language, commonly "
+"used for scripting interactive behavior on web pages and in web "
+"applications."
+msgstr ""
+"JavaScript është një gjuhë programi object-oriented, e peshës së lehtë, e "
+"përdorur rëndom për programim ndërveprimesh mes përdoruesit dhe faqesh apo "
+"aplikacionesh web."
 
 #: kuma/demos/__init__.py:290
 msgid "https://developer.mozilla.org/en-US/docs/Web/JavaScript"
@@ -1295,8 +1570,11 @@ msgid "HTML5"
 msgstr "HTML5"
 
 #: kuma/demos/__init__.py:296
-msgid "HTML5 is the newest version of the HTML standard, currently under development."
-msgstr "HTML5 është versioni më i ri i standardit HTML, ende në zhvillim e sipër."
+msgid ""
+"HTML5 is the newest version of the HTML standard, currently under "
+"development."
+msgstr ""
+"HTML5 është versioni më i ri i standardit HTML, ende në zhvillim e sipër."
 
 #: kuma/demos/__init__.py:298
 msgid "https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5"
@@ -1311,8 +1589,14 @@ msgid "http://dev.w3.org/html5/spec/Overview.html"
 msgstr "http://dev.w3.org/html5/spec/Overview.html"
 
 #: kuma/demos/__init__.py:304
-msgid "IndexedDB is an API for client-side storage of significant amounts of structured data and for high performance searches on this data using indexes."
-msgstr "IndexedDB është një API për depozitim, nga krahu i klientit, i sasive të mëdha të dhënash të strukturuara dhe për kërkime të fuqishme mbi këto të dhëna duke përdorur tregues (indekse)."
+msgid ""
+"IndexedDB is an API for client-side storage of significant amounts of "
+"structured data and for high performance searches on this data using "
+"indexes."
+msgstr ""
+"IndexedDB është një API për depozitim, nga krahu i klientit, i sasive të "
+"mëdha të dhënash të strukturuara dhe për kërkime të fuqishme mbi këto të "
+"dhëna duke përdorur tregues (indekse)."
 
 #: kuma/demos/__init__.py:306
 msgid "https://developer.mozilla.org/en-US/docs/IndexedDB"
@@ -1327,8 +1611,12 @@ msgid "http://www.w3.org/TR/IndexedDB/"
 msgstr "http://www.w3.org/TR/IndexedDB/"
 
 #: kuma/demos/__init__.py:312
-msgid "Drag and Drop features allow the user to move elements on the screen using the mouse pointer."
-msgstr "Veçoritë Merr dhe Vër i lejojnë përdoruesit të lëvizë elemente në ekran duke përdorur kursorin."
+msgid ""
+"Drag and Drop features allow the user to move elements on the screen using "
+"the mouse pointer."
+msgstr ""
+"Veçoritë Merr dhe Vër i lejojnë përdoruesit të lëvizë elemente në ekran duke"
+" përdorur kursorin."
 
 #: kuma/demos/__init__.py:314
 msgid "https://developer.mozilla.org/en-US/docs/DragDrop/Drag_and_Drop"
@@ -1343,8 +1631,12 @@ msgid "http://www.w3.org/TR/html5/dnd.html"
 msgstr "http://www.w3.org/TR/html5/dnd.html"
 
 #: kuma/demos/__init__.py:320
-msgid "Firefox Mobile brings the true Web experience to mobile phones and other non-PC devices."
-msgstr "Firefox Mobile sjell te telefonat celularë dhe të tjera pajisje jo PC ndjesitë e vërteta Web."
+msgid ""
+"Firefox Mobile brings the true Web experience to mobile phones and other "
+"non-PC devices."
+msgstr ""
+"Firefox Mobile sjell te telefonat celularë dhe të tjera pajisje jo PC "
+"ndjesitë e vërteta Web."
 
 #: kuma/demos/__init__.py:322
 msgid "https://developer.mozilla.org/en-US/docs/Mozilla/Mobile"
@@ -1363,12 +1655,18 @@ msgid "Offline Support"
 msgstr "Asistencë Jo Në Internet"
 
 #: kuma/demos/__init__.py:328
-msgid "Offline caching of web applications' resources using the application cache and local storage."
-msgstr "Ruajtje në fshehtinë jashtë linje e burimeve të aplikacioneve web, përmes fshehtinës së aplikacionit dhe depos vendore."
+msgid ""
+"Offline caching of web applications' resources using the application cache "
+"and local storage."
+msgstr ""
+"Ruajtje në fshehtinë jashtë linje e burimeve të aplikacioneve web, përmes "
+"fshehtinës së aplikacionit dhe depos vendore."
 
 #: kuma/demos/__init__.py:330
-msgid "https://developer.mozilla.org/en-US/docs/Web/Guide/DOM/Storage#localStorage"
-msgstr "https://developer.mozilla.org/en-US/docs/Web/Guide/DOM/Storage#localStorage"
+msgid ""
+"https://developer.mozilla.org/en-US/docs/Web/Guide/DOM/Storage#localStorage"
+msgstr ""
+"https://developer.mozilla.org/en-US/docs/Web/Guide/DOM/Storage#localStorage"
 
 #: kuma/demos/__init__.py:331
 msgid "http://en.wikipedia.org/wiki/Web_Storage"
@@ -1379,8 +1677,12 @@ msgid "http://dev.w3.org/html5/webstorage/"
 msgstr "http://dev.w3.org/html5/webstorage/"
 
 #: kuma/demos/__init__.py:336
-msgid "Scalable Vector Graphics (SVG) is an XML based language for describing two-dimensional vector graphics."
-msgstr "Scalable Vector Graphics (SVG) është një gjuhë me bazë XML për përshkrim grafikash vektoriale dypërmasore."
+msgid ""
+"Scalable Vector Graphics (SVG) is an XML based language for describing two-"
+"dimensional vector graphics."
+msgstr ""
+"Scalable Vector Graphics (SVG) është një gjuhë me bazë XML për përshkrim "
+"grafikash vektoriale dypërmasore."
 
 #: kuma/demos/__init__.py:338
 msgid "https://developer.mozilla.org/en-US/docs/Web/SVG"
@@ -1399,12 +1701,20 @@ msgid "Video"
 msgstr "Video"
 
 #: kuma/demos/__init__.py:344
-msgid "The HTML5 video element provides integrated support for playing video media without requiring plug-ins."
-msgstr "Elementët video HTML5 furnizojnë mbulim të integruar për luajtje videosh, pa u dashur shtojca."
+msgid ""
+"The HTML5 video element provides integrated support for playing video media "
+"without requiring plug-ins."
+msgstr ""
+"Elementët video HTML5 furnizojnë mbulim të integruar për luajtje videosh, pa"
+" u dashur shtojca."
 
 #: kuma/demos/__init__.py:346
-msgid "https://developer.mozilla.org/en-US/docs/Web/HTML/Using_HTML5_audio_and_video"
-msgstr "https://developer.mozilla.org/en-US/docs/Web/HTML/Using_HTML5_audio_and_video"
+msgid ""
+"https://developer.mozilla.org/en-"
+"US/docs/Web/HTML/Using_HTML5_audio_and_video"
+msgstr ""
+"https://developer.mozilla.org/en-"
+"US/docs/Web/HTML/Using_HTML5_audio_and_video"
 
 #: kuma/demos/__init__.py:347
 msgid "http://en.wikipedia.org/wiki/HTML5_video"
@@ -1415,8 +1725,12 @@ msgid "http://www.w3.org/TR/html5/embedded-content-0.html#the-video-element"
 msgstr "http://www.w3.org/TR/html5/embedded-content-0.html#the-video-element"
 
 #: kuma/demos/__init__.py:352
-msgid "In the context of the HTML canvas element WebGL provides an API for 3D graphics in the browser."
-msgstr "Në kontekstin e elementëve kanavacë HTML, WebGL furnizon një API për grafikë 3D te shfletuesi."
+msgid ""
+"In the context of the HTML canvas element WebGL provides an API for 3D "
+"graphics in the browser."
+msgstr ""
+"Në kontekstin e elementëve kanavacë HTML, WebGL furnizon një API për grafikë"
+" 3D te shfletuesi."
 
 #: kuma/demos/__init__.py:354
 msgid "https://developer.mozilla.org/en-US/docs/Web/WebGL"
@@ -1439,8 +1753,12 @@ msgid "WebSockets"
 msgstr "WebSockets"
 
 #: kuma/demos/__init__.py:360
-msgid "WebSockets is a technology that makes it possible to open an interactive communication session between the user's browser and a server."
-msgstr "WebSockets është një teknologji që bën të mundur hapjen e një sesioni ndërveprues komunikimesh mes shfletuesit të përdoruesit dhe një shërbyesi."
+msgid ""
+"WebSockets is a technology that makes it possible to open an interactive "
+"communication session between the user's browser and a server."
+msgstr ""
+"WebSockets është një teknologji që bën të mundur hapjen e një sesioni "
+"ndërveprues komunikimesh mes shfletuesit të përdoruesit dhe një shërbyesi."
 
 #: kuma/demos/__init__.py:362
 msgid "https://developer.mozilla.org/en-US/docs/WebSockets"
@@ -1455,12 +1773,20 @@ msgid "http://dev.w3.org/html5/websockets/"
 msgstr "http://dev.w3.org/html5/websockets/"
 
 #: kuma/demos/__init__.py:368
-msgid "Web Workers provide a simple means for web content to run scripts in background threads."
-msgstr "Web Workers ofron një rrugë të thjeshtë që lënda web të xhirojë programthe në rrjedha në prapaskenë."
+msgid ""
+"Web Workers provide a simple means for web content to run scripts in "
+"background threads."
+msgstr ""
+"Web Workers ofron një rrugë të thjeshtë që lënda web të xhirojë programthe "
+"në rrjedha në prapaskenë."
 
 #: kuma/demos/__init__.py:370
-msgid "https://developer.mozilla.org/en-US/docs/Web/Guide/Performance/Using_web_workers"
-msgstr "https://developer.mozilla.org/en-US/docs/Web/Guide/Performance/Using_web_workers"
+msgid ""
+"https://developer.mozilla.org/en-"
+"US/docs/Web/Guide/Performance/Using_web_workers"
+msgstr ""
+"https://developer.mozilla.org/en-"
+"US/docs/Web/Guide/Performance/Using_web_workers"
 
 #: kuma/demos/__init__.py:371
 msgid "http://en.wikipedia.org/wiki/Web_Workers"
@@ -1475,12 +1801,21 @@ msgid "XMLHttpRequest"
 msgstr "XMLHttpRequest"
 
 #: kuma/demos/__init__.py:376
-msgid "XMLHttpRequest (XHR) is used to send HTTP requests directly to a webserver and load the response data directly back into the script."
-msgstr "XMLHttpRequest (XHR) përdoret për të dërguar kërkesa HTTP drejt e te një shërbyes dhe për ngarkimin e të dhënave drejt e te programthi që bëri kërkesën."
+msgid ""
+"XMLHttpRequest (XHR) is used to send HTTP requests directly to a webserver "
+"and load the response data directly back into the script."
+msgstr ""
+"XMLHttpRequest (XHR) përdoret për të dërguar kërkesa HTTP drejt e te një "
+"shërbyes dhe për ngarkimin e të dhënave drejt e te programthi që bëri "
+"kërkesën."
 
 #: kuma/demos/__init__.py:378
-msgid "https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest"
-msgstr "https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest"
+msgid ""
+"https://developer.mozilla.org/en-"
+"US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest"
+msgstr ""
+"https://developer.mozilla.org/en-"
+"US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest"
 
 #: kuma/demos/__init__.py:379
 msgid "http://en.wikipedia.org/wiki/XMLHttpRequest"
@@ -1491,12 +1826,18 @@ msgid "http://www.w3.org/TR/XMLHttpRequest/"
 msgstr "http://www.w3.org/TR/XMLHttpRequest/"
 
 #: kuma/demos/__init__.py:384
-msgid "Track the movement of the user's finger on a touch screen, monitoring the raw touch events generated by the system."
-msgstr "Ndiqni lëvizjet e gishtit të përdoruesit një ekran me prekje, duke mbikëqyrur akte prekjesh të prodhuar nga sistemi."
+msgid ""
+"Track the movement of the user's finger on a touch screen, monitoring the "
+"raw touch events generated by the system."
+msgstr ""
+"Ndiqni lëvizjet e gishtit të përdoruesit një ekran me prekje, duke "
+"mbikëqyrur akte prekjesh të prodhuar nga sistemi."
 
 #: kuma/demos/__init__.py:386
-msgid "https://developer.mozilla.org/en-US/docs/Web/Guide/DOM/Events/Touch_events"
-msgstr "https://developer.mozilla.org/en-US/docs/Web/Guide/DOM/Events/Touch_events"
+msgid ""
+"https://developer.mozilla.org/en-US/docs/Web/Guide/DOM/Events/Touch_events"
+msgstr ""
+"https://developer.mozilla.org/en-US/docs/Web/Guide/DOM/Events/Touch_events"
 
 #: kuma/demos/__init__.py:387
 msgid "http://en.wikipedia.org/wiki/Multi-touch"
@@ -1563,7 +1904,7 @@ msgstr "Jeni i sigurt?"
 #: kuma/demos/admin.py:68
 #, python-format
 msgid "Censor selected %(verbose_name_plural)s"
-msgstr ""
+msgstr "Censuro të përzgjedhurin %(verbose_name_plural)s"
 
 #: kuma/demos/admin.py:106
 #, python-format
@@ -1583,7 +1924,7 @@ msgstr "S’fshihet dot %(name)s"
 #: kuma/demos/admin.py:146
 #, python-format
 msgid "Delete selected %(verbose_name_plural)s"
-msgstr ""
+msgstr "Fshi të përzgjedhurin %(verbose_name_plural)s"
 
 #: kuma/demos/embed.py:128
 msgid "Not an URL from a supported video service"
@@ -1689,8 +2030,11 @@ msgstr "%(number)d %(type)s"
 
 #: kuma/demos/models.py:204
 #, python-format
-msgid "Please keep filesize under %(max_size)s. Current filesize %(file_size)s"
-msgstr "Ju lutemi, mbajeni madhësinë e kartelës %(max_size)s. Madhësia e tanishme e kartelës %(file_size)s"
+msgid ""
+"Please keep filesize under %(max_size)s. Current filesize %(file_size)s"
+msgstr ""
+"Ju lutemi, mbajeni madhësinë e kartelës %(max_size)s. Madhësia e tanishme e "
+"kartelës %(file_size)s"
 
 #: kuma/demos/models.py:275
 msgid "Cannot process image"
@@ -1761,8 +2105,12 @@ msgid "select a ZIP file containing your demo"
 msgstr "përzgjidhni një kartelë ZIP që përmban demon tuaj"
 
 #: kuma/demos/models.py:442
-msgid "Is your source code also available somewhere else on the web (e.g., github)? Please share the link."
-msgstr "A gjendet kodi juaj burim gjetkë në web (p.sh., github)? Ju lutemi, ndajeni lidhjen me të tjerët."
+msgid ""
+"Is your source code also available somewhere else on the web (e.g., github)?"
+" Please share the link."
+msgstr ""
+"A gjendet kodi juaj burim gjetkë në web (p.sh., github)? Ju lutemi, ndajeni "
+"lidhjen me të tjerët."
 
 #: kuma/demos/models.py:445
 msgid "Select the license that applies to your source code."
@@ -1794,11 +2142,14 @@ msgstr "Kartela ZIP përmban një kartelë të papranueshme: %(filename)s"
 msgid "HTML index not found in ZIP"
 msgstr "S’u gjet treguesi HTML në ZIP"
 
-#: kuma/demos/views.py:73 kuma/demos/views.py:300 kuma/demos/views.py:328 kuma/demos/views.py:343
+#: kuma/demos/views.py:73 kuma/demos/views.py:300 kuma/demos/views.py:328
+#: kuma/demos/views.py:343
 msgid "access denied"
 msgstr "hyrje e mohuar"
 
-#: kuma/demos/templates/admin/demos/submission/censor_selected_confirmation.html:6 kuma/demos/templates/demos/devderby_tag.html:21 kuma/wiki/templates/admin/wiki/purge_documents.html:22
+#: kuma/demos/templates/admin/demos/submission/censor_selected_confirmation.html:6
+#: kuma/demos/templates/demos/devderby_tag.html:21
+#: kuma/wiki/templates/admin/wiki/purge_documents.html:22
 #: kuma/wiki/templates/admin/wiki/document/load_data_form.html:22
 msgid "Home"
 msgstr "Hyrje"
@@ -1809,8 +2160,12 @@ msgstr "Censuroni shumë objekte njëherësh"
 
 #: kuma/demos/templates/admin/demos/submission/censor_selected_confirmation.html:14
 #, python-format
-msgid "Are you sure you want to censor the selected %(object_name)s objects? This cannot be reversed."
-msgstr "Jeni i sigurt se doni të censurohen objektet %(object_name)s e përzgjedhur? Kjo s’mund të zhbëhet."
+msgid ""
+"Are you sure you want to censor the selected %(object_name)s objects? This "
+"cannot be reversed."
+msgstr ""
+"Jeni i sigurt se doni të censurohen objektet %(object_name)s e përzgjedhur? "
+"Kjo s’mund të zhbëhet."
 
 #: kuma/demos/templates/admin/demos/submission/censor_selected_confirmation.html:23
 msgid "Explanation URL (optional):"
@@ -1820,9 +2175,18 @@ msgstr "URL Shpjegimi (në dëshirë):"
 msgid "Yes, I'm sure"
 msgstr "Po, jam i sigurt"
 
-#: kuma/demos/templates/demos/delete.html:10 kuma/demos/templates/demos/detail.html:9 kuma/demos/templates/demos/devderby_tag.html:5 kuma/demos/templates/demos/flag.html:10
-#: kuma/demos/templates/demos/launch.html:6 kuma/demos/templates/demos/listing_all.html:4 kuma/demos/templates/demos/listing_search.html:9 kuma/demos/templates/demos/listing_tag.html:4
-#: kuma/demos/templates/demos/submit.html:13 kuma/demos/templates/demos/submit.html:15 kuma/demos/templates/demos/submit_noauth.html:11 kuma/demos/templates/demos/terms.html:10
+#: kuma/demos/templates/demos/delete.html:10
+#: kuma/demos/templates/demos/detail.html:9
+#: kuma/demos/templates/demos/devderby_tag.html:5
+#: kuma/demos/templates/demos/flag.html:10
+#: kuma/demos/templates/demos/launch.html:6
+#: kuma/demos/templates/demos/listing_all.html:4
+#: kuma/demos/templates/demos/listing_search.html:9
+#: kuma/demos/templates/demos/listing_tag.html:4
+#: kuma/demos/templates/demos/submit.html:13
+#: kuma/demos/templates/demos/submit.html:15
+#: kuma/demos/templates/demos/submit_noauth.html:11
+#: kuma/demos/templates/demos/terms.html:10
 #, python-format
 msgid "%(subtitle)s | Demo Studio"
 msgstr "%(subtitle)s | Studio Demosh"
@@ -1831,11 +2195,17 @@ msgstr "%(subtitle)s | Studio Demosh"
 msgid "MDN"
 msgstr "MDN"
 
-#: kuma/demos/templates/demos/delete.html:21 kuma/demos/templates/demos/detail.html:14 kuma/demos/templates/demos/home.html:14 kuma/demos/templates/demos/launch.html:15
+#: kuma/demos/templates/demos/delete.html:21
+#: kuma/demos/templates/demos/detail.html:14
+#: kuma/demos/templates/demos/home.html:14
+#: kuma/demos/templates/demos/launch.html:15
 msgid "Demo Studio"
 msgstr "Studio Demosh"
 
-#: kuma/demos/templates/demos/delete.html:26 kuma/demos/templates/demos/detail.html:32 kuma/demos/templates/demos/home.html:23 kuma/demos/templates/demos/elements/demos_head.html:4
+#: kuma/demos/templates/demos/delete.html:26
+#: kuma/demos/templates/demos/detail.html:32
+#: kuma/demos/templates/demos/home.html:23
+#: kuma/demos/templates/demos/elements/demos_head.html:4
 msgid "Submit a Demo"
 msgstr "Parashtroni një Demo"
 
@@ -1846,36 +2216,60 @@ msgstr "Të hiqet kjo demo?"
 #: kuma/demos/templates/demos/delete.html:40
 #, python-format
 msgid ""
-"<p>You are about to remove <strong>%(demo_title)s</strong> from the Demo Studio.</p> <p>The Demo's listing, source code, and statistics will be <strong>deleted</strong>.</p> <p>This action "
-"<strong>cannot be undone</strong>."
+"<p>You are about to remove <strong>%(demo_title)s</strong> from the Demo "
+"Studio.</p> <p>The Demo's listing, source code, and statistics will be "
+"<strong>deleted</strong>.</p> <p>This action <strong>cannot be "
+"undone</strong>."
 msgstr ""
-"<p>Ju ndan një hap nga heqja e <strong>%(demo_title)s</strong> prej Studios së Demove.</p> <p>Paraqitja në arkivat e Demos, kodi burim, dhe statistikat do të <strong>fshihen</strong>.</p> <p>Ky "
-"veprim <strong>s’mund të zhbëhet</strong>."
+"<p>Ju ndan një hap nga heqja e <strong>%(demo_title)s</strong> prej Studios "
+"së Demove.</p> <p>Paraqitja në arkivat e Demos, kodi burim, dhe statistikat "
+"do të <strong>fshihen</strong>.</p> <p>Ky veprim <strong>s’mund të "
+"zhbëhet</strong>."
 
 #: kuma/demos/templates/demos/delete.html:49
 msgid "<button type=\"submit\" class=\"remove\"><span>Remove demo</span></button>"
 msgstr "<button type=\"submit\" class=\"remove\"><span>Hiqeni demon</span></button>"
 
-#: kuma/demos/templates/demos/detail.html:30 kuma/demos/templates/demos/devderby_landing.html:22 kuma/demos/templates/demos/devderby_tag.html:32 kuma/demos/templates/demos/home.html:21
-#: kuma/demos/templates/demos/submit.html:45 kuma/demos/templates/demos/submit_noauth.html:20 kuma/demos/templates/demos/elements/demos_head.html:2
+#: kuma/demos/templates/demos/detail.html:30
+#: kuma/demos/templates/demos/devderby_landing.html:22
+#: kuma/demos/templates/demos/devderby_tag.html:32
+#: kuma/demos/templates/demos/home.html:21
+#: kuma/demos/templates/demos/submit.html:45
+#: kuma/demos/templates/demos/submit_noauth.html:20
+#: kuma/demos/templates/demos/elements/demos_head.html:2
 msgid "Mozilla Demo Studio"
 msgstr "Studioja Mozilla Demo"
 
-#: kuma/demos/templates/demos/detail.html:33 kuma/demos/templates/demos/home.html:24 kuma/demos/templates/demos/listing_tag.html:37 kuma/demos/templates/demos/elements/demos_head.html:5
+#: kuma/demos/templates/demos/detail.html:33
+#: kuma/demos/templates/demos/home.html:24
+#: kuma/demos/templates/demos/listing_tag.html:37
+#: kuma/demos/templates/demos/elements/demos_head.html:5
 msgid "Learn More"
 msgstr "Mësoni Më Tepër"
 
-#: kuma/demos/templates/demos/detail.html:35 kuma/demos/templates/demos/home.html:26 kuma/demos/templates/demos/elements/demos_head.html:7
+#: kuma/demos/templates/demos/detail.html:35
+#: kuma/demos/templates/demos/home.html:26
+#: kuma/demos/templates/demos/elements/demos_head.html:7
 msgid ""
-"<p>Welcome to the Mozilla Demo Studio, where developers like you can develop, share, demonstrate, and learn all about Web technologies. See what's possible by exploring Demo Studio:</p> <ul> "
-"<li>View demos that showcase what HTML, CSS, and JavaScript can do.</li> <li>Inspect the source code for those demos so you can see how they work.</li> <li>Read documentation to learn about the "
-"open standards and technologies that power the Web.</li> </ul>"
+"<p>Welcome to the Mozilla Demo Studio, where developers like you can "
+"develop, share, demonstrate, and learn all about Web technologies. See "
+"what's possible by exploring Demo Studio:</p> <ul> <li>View demos that "
+"showcase what HTML, CSS, and JavaScript can do.</li> <li>Inspect the source "
+"code for those demos so you can see how they work.</li> <li>Read "
+"documentation to learn about the open standards and technologies that power "
+"the Web.</li> </ul>"
 msgstr ""
-"<p>Mirë se vini te Mozilla Demo Studio, ku zhvillues si ju mund të zhvillojnë, ndajnë me të tjerët, demonstrojnë dhe të mësojnë gjithçka rreth teknologjive Web. Shihni se ç’është e mundur, duke "
-"eksploruar Studion e Demove:</p> <ul> <li>Shihni demo që tregojnë se ç’mund të arrini me HTML-në, CSS-në, dhe JavaScript-in.</li> <li>Shqyrtoni kodin burim të këtyre demove, që të shihni se si "
-"funksionojnë.</li> <li>Lexoni dokumentimin që të mësoni rreth standardeve të hapura dhe teknologjive që mbajnë në këmbë Web-in.</li> </ul>"
+"<p>Mirë se vini te Mozilla Demo Studio, ku zhvillues si ju mund të "
+"zhvillojnë, ndajnë me të tjerët, demonstrojnë dhe të mësojnë gjithçka rreth "
+"teknologjive Web. Shihni se ç’është e mundur, duke eksploruar Studion e "
+"Demove:</p> <ul> <li>Shihni demo që tregojnë se ç’mund të arrini me HTML-në,"
+" CSS-në, dhe JavaScript-in.</li> <li>Shqyrtoni kodin burim të këtyre demove,"
+" që të shihni se si funksionojnë.</li> <li>Lexoni dokumentimin që të mësoni "
+"rreth standardeve të hapura dhe teknologjive që mbajnë në këmbë Web-in.</li>"
+" </ul>"
 
-#: kuma/demos/templates/demos/detail.html:51 kuma/demos/templates/demos/launch.html:80
+#: kuma/demos/templates/demos/detail.html:51
+#: kuma/demos/templates/demos/launch.html:80
 #, python-format
 msgid "Go to the previous demo, %(demo_title)s"
 msgstr "Shko tek demoja e mëparshme, %(demo_title)s"
@@ -1884,13 +2278,19 @@ msgstr "Shko tek demoja e mëparshme, %(demo_title)s"
 msgid "Prev"
 msgstr "E mëparshmja"
 
-#: kuma/demos/templates/demos/detail.html:55 kuma/demos/templates/demos/launch.html:84
+#: kuma/demos/templates/demos/detail.html:55
+#: kuma/demos/templates/demos/launch.html:84
 #, python-format
 msgid "Go to the next demo, %(demo_title)s"
 msgstr "Shko tek demoja pasuese, %(demo_title)s"
 
-#: kuma/demos/templates/demos/detail.html:55 kuma/demos/templates/demos/detail.html:69 kuma/demos/templates/demos/home.html:47 kuma/demos/templates/demos/launch.html:84
-#: kuma/demos/templates/demos/elements/submission_listing.html:64 kuma/search/templates/search/results.html:159 templates/includes/paginator.html:30
+#: kuma/demos/templates/demos/detail.html:55
+#: kuma/demos/templates/demos/detail.html:69
+#: kuma/demos/templates/demos/home.html:47
+#: kuma/demos/templates/demos/launch.html:84
+#: kuma/demos/templates/demos/elements/submission_listing.html:64
+#: kuma/search/templates/search/results.html:159
+#: templates/includes/paginator.html:30
 msgid "Next"
 msgstr "Pasuesja"
 
@@ -1898,8 +2298,13 @@ msgstr "Pasuesja"
 msgid "See the previous image"
 msgstr "Shihni figurën e mëparshme"
 
-#: kuma/demos/templates/demos/detail.html:68 kuma/demos/templates/demos/home.html:46 kuma/demos/templates/demos/launch.html:80 kuma/demos/templates/demos/elements/submission_listing.html:61
-#: kuma/search/templates/search/results.html:154 kuma/wiki/templates/wiki/list/revisions.html:56 templates/includes/paginator.html:6
+#: kuma/demos/templates/demos/detail.html:68
+#: kuma/demos/templates/demos/home.html:46
+#: kuma/demos/templates/demos/launch.html:80
+#: kuma/demos/templates/demos/elements/submission_listing.html:61
+#: kuma/search/templates/search/results.html:154
+#: kuma/wiki/templates/wiki/list/revisions.html:56
+#: templates/includes/paginator.html:6
 msgid "Previous"
 msgstr "E mëparshmja"
 
@@ -1916,35 +2321,44 @@ msgstr "Nga %(creator_link)s më %(create_date)s"
 msgid "Launch Demo"
 msgstr "Nise Demon"
 
-#: kuma/demos/templates/demos/detail.html:124 kuma/demos/templates/demos/launch.html:46
+#: kuma/demos/templates/demos/detail.html:124
+#: kuma/demos/templates/demos/launch.html:46
 msgid "You like this demo. Undo?"
 msgstr "E pëlqeni këtë demo. Të zhbëhet?"
 
-#: kuma/demos/templates/demos/detail.html:124 kuma/demos/templates/demos/launch.html:46
+#: kuma/demos/templates/demos/detail.html:124
+#: kuma/demos/templates/demos/launch.html:46
 msgid "You Like"
 msgstr "E Pëlqeni"
 
-#: kuma/demos/templates/demos/detail.html:130 kuma/demos/templates/demos/launch.html:52
+#: kuma/demos/templates/demos/detail.html:130
+#: kuma/demos/templates/demos/launch.html:52
 msgid "Do you like this demo?"
 msgstr "A ju pëlqen kjo demo?"
 
-#: kuma/demos/templates/demos/detail.html:130 kuma/demos/templates/demos/launch.html:52
+#: kuma/demos/templates/demos/detail.html:130
+#: kuma/demos/templates/demos/launch.html:52
 msgid "Like It"
 msgstr "Më pëlqen"
 
-#: kuma/demos/templates/demos/detail.html:135 kuma/demos/templates/demos/launch.html:56
+#: kuma/demos/templates/demos/detail.html:135
+#: kuma/demos/templates/demos/launch.html:56
 msgid "Share this demo with your social network"
 msgstr "Ndajeni këtë demo me të tjerë te rrjeti juaj shoqëror"
 
-#: kuma/demos/templates/demos/detail.html:135 kuma/demos/templates/demos/detail.html:137 kuma/demos/templates/demos/launch.html:56
+#: kuma/demos/templates/demos/detail.html:135
+#: kuma/demos/templates/demos/detail.html:137
+#: kuma/demos/templates/demos/launch.html:56
 msgid "Share It"
 msgstr "Ndaje"
 
-#: kuma/demos/templates/demos/detail.html:138 kuma/demos/templates/demos/launch.html:58
+#: kuma/demos/templates/demos/detail.html:138
+#: kuma/demos/templates/demos/launch.html:58
 msgid "Share on Twitter"
 msgstr "Ndajeni me të tjerët në Twitter"
 
-#: kuma/demos/templates/demos/detail.html:139 kuma/demos/templates/demos/launch.html:59
+#: kuma/demos/templates/demos/detail.html:139
+#: kuma/demos/templates/demos/launch.html:59
 msgid "Share on Facebook"
 msgstr "Ndajeni me të tjerët në Facebook"
 
@@ -1957,7 +2371,8 @@ msgstr "Krijuar duke përdorur"
 msgid "See more demos made with %(tag_title)s"
 msgstr "Shihni më tepër demo të krijuara me %(tag_title)s"
 
-#: kuma/demos/templates/demos/detail.html:165 kuma/demos/templates/demos/elements/submission_thumb.html:15
+#: kuma/demos/templates/demos/detail.html:165
+#: kuma/demos/templates/demos/elements/submission_thumb.html:15
 #, python-format
 msgid "This demo has been viewed %(num)s time"
 msgid_plural "This demo has been viewed %(num)s times"
@@ -1971,7 +2386,8 @@ msgid_plural "%(num)s views"
 msgstr[0] "%(num)s parje"
 msgstr[1] "%(num)s parje"
 
-#: kuma/demos/templates/demos/detail.html:166 kuma/demos/templates/demos/elements/submission_thumb.html:16
+#: kuma/demos/templates/demos/detail.html:166
+#: kuma/demos/templates/demos/elements/submission_thumb.html:16
 #, python-format
 msgid "%(num)s person liked this demo"
 msgid_plural "%(num)s people liked this demo"
@@ -2011,13 +2427,20 @@ msgstr "Rreth kësaj Demoje"
 
 #: kuma/demos/templates/demos/detail.html:209
 #, python-format
-msgid "Download the Source <span class=\"note\">%(file_ksize)s KB &middot; ZIP File</span>"
-msgstr "Shkarkoni <span class=\"note\">Kartelën ZIP &middot; %(file_ksize)s KB</span> të Burimit"
+msgid ""
+"Download the Source <span class=\"note\">%(file_ksize)s KB &middot; ZIP "
+"File</span>"
+msgstr ""
+"Shkarkoni <span class=\"note\">Kartelën ZIP &middot; %(file_ksize)s "
+"KB</span> të Burimit"
 
 #: kuma/demos/templates/demos/detail.html:217
 #, python-format
-msgid "This demo is released under the <a href=\"%(link)s\">%(title)s</a> license."
-msgstr "Kjo demo është hedhur në qarkullim nën lejen <a href=\"%(link)s\">%(title)s</a>."
+msgid ""
+"This demo is released under the <a href=\"%(link)s\">%(title)s</a> license."
+msgstr ""
+"Kjo demo është hedhur në qarkullim nën lejen <a "
+"href=\"%(link)s\">%(title)s</a>."
 
 # 77%
 # 100%
@@ -2026,11 +2449,14 @@ msgstr "Kjo demo është hedhur në qarkullim nën lejen <a href=\"%(link)s\">%(
 msgid "More by %(creator)s"
 msgstr "Më tepër nga %(creator)s"
 
-#: kuma/demos/templates/demos/detail.html:237 kuma/demos/templates/demos/launch.html:63
+#: kuma/demos/templates/demos/detail.html:237
+#: kuma/demos/templates/demos/launch.html:63
 msgid "Report a Problem"
 msgstr "Raportoni një Problem"
 
-#: kuma/demos/templates/demos/detail.html:239 kuma/demos/templates/demos/detail.html:240 kuma/demos/templates/demos/detail.html:241
+#: kuma/demos/templates/demos/detail.html:239
+#: kuma/demos/templates/demos/detail.html:240
+#: kuma/demos/templates/demos/detail.html:241
 msgid "Flag Content"
 msgstr "I Vini Shenjë Lëndës"
 
@@ -2046,11 +2472,14 @@ msgstr "Demoja është e papërshtatshme"
 msgid "Demo is not by this author"
 msgstr "Demoja s’është nga ky autor"
 
-#: kuma/demos/templates/demos/devderby_landing.html:11 kuma/demos/templates/demos/devderby_landing.html:23 kuma/demos/templates/demos/devderby_tag.html:33
+#: kuma/demos/templates/demos/devderby_landing.html:11
+#: kuma/demos/templates/demos/devderby_landing.html:23
+#: kuma/demos/templates/demos/devderby_tag.html:33
 msgid "Dev Derby"
 msgstr "Dev Derby"
 
-#: kuma/demos/templates/demos/devderby_landing.html:22 kuma/demos/templates/demos/devderby_tag.html:32
+#: kuma/demos/templates/demos/devderby_landing.html:22
+#: kuma/demos/templates/demos/devderby_tag.html:32
 msgid "presents"
 msgstr "paraqet"
 
@@ -2060,22 +2489,31 @@ msgstr "Dev Derby ka përfunduar"
 
 #: kuma/demos/templates/demos/devderby_landing.html:27
 #, python-format
-msgid "From 2011 until 2013, web developers created more than 450 demos for the Dev Derby! Find them below, or <a href=\"%(demos_url)s\">visit the Demo Studio</a> for many more."
-msgstr "Nga 2011 deri më 2013, zhvilluesit web krijuan më shumë se 450 demo për Dev Derby-n! Shihni më poshtë, ose <a href=\"%(demos_url)s\">vizitoni Studion e Demove</a> për shumë më tepër."
+msgid ""
+"From 2011 until 2013, web developers created more than 450 demos for the Dev"
+" Derby! Find them below, or <a href=\"%(demos_url)s\">visit the Demo "
+"Studio</a> for many more."
+msgstr ""
+"Nga 2011 deri më 2013, zhvilluesit web krijuan më shumë se 450 demo për Dev "
+"Derby-n! Shihni më poshtë, ose <a href=\"%(demos_url)s\">vizitoni Studion e "
+"Demove</a> për shumë më tepër."
 
 #: kuma/demos/templates/demos/devderby_landing.html:40
 msgid "Previous Dev Derby Challenges"
 msgstr "Gara Dev Derby të Mëparshme"
 
-#: kuma/demos/templates/demos/devderby_landing.html:55 kuma/demos/templates/demos/devderby_tag.html:25
+#: kuma/demos/templates/demos/devderby_landing.html:55
+#: kuma/demos/templates/demos/devderby_tag.html:25
 msgid "Resources"
 msgstr "Burime"
 
-#: kuma/demos/templates/demos/devderby_landing.html:57 kuma/search/templates/search/results.html:141
+#: kuma/demos/templates/demos/devderby_landing.html:57
+#: kuma/search/templates/search/results.html:141
 msgid "Docs"
 msgstr "Dokumentim"
 
-#: kuma/demos/templates/demos/devderby_landing.html:58 templates/base.html:144 templates/base.html:162
+#: kuma/demos/templates/demos/devderby_landing.html:58 templates/base.html:144
+#: templates/base.html:162
 msgid "Demos"
 msgstr "Demo"
 
@@ -2083,7 +2521,8 @@ msgstr "Demo"
 msgid "Articles"
 msgstr "Artikuj"
 
-#: kuma/demos/templates/demos/devderby_tag.html:8 kuma/demos/templates/demos/listing_tag.html:7
+#: kuma/demos/templates/demos/devderby_tag.html:8
+#: kuma/demos/templates/demos/listing_tag.html:7
 #, python-format
 msgid "Demos tagged %(tag)s"
 msgstr "Demo të etiketuara me %(tag)s"
@@ -2108,7 +2547,9 @@ msgstr "Fitues të Derby-t"
 msgid "Submissions"
 msgstr "Parashtrime"
 
-#: kuma/demos/templates/demos/devderby_tag.html:55 kuma/demos/templates/demos/home.html:136 kuma/demos/templates/demos/listing_tag.html:51
+#: kuma/demos/templates/demos/devderby_tag.html:55
+#: kuma/demos/templates/demos/home.html:136
+#: kuma/demos/templates/demos/listing_tag.html:51
 #, python-format
 msgid "Subscribe to a feed of %(tag_title)s demos"
 msgstr "Pajtohuni te prurja për demo me %(tag_title)s"
@@ -2129,7 +2570,8 @@ msgstr "T’i vihet shenjë kësaj demoje?"
 msgid "<button type=\"submit\" name=\"action_create\">Flag content</button>"
 msgstr "<button type=\"submit\" name=\"action_create\">I vini shenjë lëndës</button>"
 
-#: kuma/demos/templates/demos/home.html:8 kuma/demos/templates/demos/listing_all.html:6
+#: kuma/demos/templates/demos/home.html:8
+#: kuma/demos/templates/demos/listing_all.html:6
 msgid "Recent demos"
 msgstr "Demo së fundi"
 
@@ -2149,7 +2591,8 @@ msgstr "Shihni demon e mëparshme"
 msgid "See the next demo"
 msgstr "Shihni demon pasuese"
 
-#: kuma/demos/templates/demos/home.html:66 kuma/demos/templates/demos/elements/submission_thumb.html:21
+#: kuma/demos/templates/demos/home.html:66
+#: kuma/demos/templates/demos/elements/submission_thumb.html:21
 msgid "Details"
 msgstr "Hollësi"
 
@@ -2157,7 +2600,8 @@ msgstr "Hollësi"
 msgid "Launch"
 msgstr "Nise"
 
-#: kuma/demos/templates/demos/home.html:106 kuma/demos/templates/demos/home.html:107
+#: kuma/demos/templates/demos/home.html:106
+#: kuma/demos/templates/demos/home.html:107
 msgid "Search demos"
 msgstr "Kërko për demo"
 
@@ -2165,7 +2609,9 @@ msgstr "Kërko për demo"
 msgid "<b>or</b>"
 msgstr "<b>ose</b>"
 
-#: kuma/demos/templates/demos/home.html:114 kuma/demos/templates/demos/elements/demos_head.html:18 kuma/demos/templates/demos/elements/tech_tags_list.html:2
+#: kuma/demos/templates/demos/home.html:114
+#: kuma/demos/templates/demos/elements/demos_head.html:18
+#: kuma/demos/templates/demos/elements/tech_tags_list.html:2
 msgid "Browse by Technology"
 msgstr "Shfletojini sipas Teknologjish"
 
@@ -2173,7 +2619,9 @@ msgstr "Shfletojini sipas Teknologjish"
 msgid "recent"
 msgstr "së fundi"
 
-#: kuma/demos/templates/demos/launch.html:32 kuma/search/templates/search/plugin.html:3 templates/base.html:12 templates/base.html:31 templates/base.html:37 templates/base.html:91
+#: kuma/demos/templates/demos/launch.html:32
+#: kuma/search/templates/search/plugin.html:3 templates/base.html:12
+#: templates/base.html:31 templates/base.html:37 templates/base.html:91
 #: templates/base.html:93 templates/base_popup.html:5
 msgid "Mozilla Developer Network"
 msgstr "Rrjeti i Zhvilluesve Mozilla"
@@ -2195,7 +2643,8 @@ msgstr "Hiqe këtë panel"
 msgid "Remove toolbar"
 msgstr "Hiqe panelin"
 
-#: kuma/demos/templates/demos/listing_all.html:4 kuma/demos/templates/demos/listing_all.html:20
+#: kuma/demos/templates/demos/listing_all.html:4
+#: kuma/demos/templates/demos/listing_all.html:20
 msgid "Browse all demos"
 msgstr "Shfletoni krejt demot"
 
@@ -2228,30 +2677,46 @@ msgstr "Pajtohuni te një prurje rreth përfundimesh kërkimi për \"%(query)s\"
 msgid "%(tag_title)s Demos"
 msgstr "Demo %(tag_title)s"
 
-#: kuma/demos/templates/demos/submit.html:13 kuma/demos/templates/demos/submit.html:53
+#: kuma/demos/templates/demos/submit.html:13
+#: kuma/demos/templates/demos/submit.html:53
 #, python-format
 msgid "Edit %(demo_title)s"
 msgstr "Përpunoni %(demo_title)s"
 
-#: kuma/demos/templates/demos/submit.html:15 kuma/demos/templates/demos/submit.html:55 kuma/demos/templates/demos/submit_noauth.html:11 kuma/demos/templates/demos/submit_noauth.html:25
+#: kuma/demos/templates/demos/submit.html:15
+#: kuma/demos/templates/demos/submit.html:55
+#: kuma/demos/templates/demos/submit_noauth.html:11
+#: kuma/demos/templates/demos/submit_noauth.html:25
 msgid "Submit a New Demo"
 msgstr "Parashtroni Demo të Re"
 
 #: kuma/demos/templates/demos/submit.html:60
 msgid ""
-"<p>Whether you are creating an amazing new way to experience the Web or just experimenting with the latest technologies, we invite you to submit your own demos to share with (or show off to) other "
-"web developers.</p> <p>Please complete the form below to ensure your demo is submitted to the Demo Studio successfully.</p>"
+"<p>Whether you are creating an amazing new way to experience the Web or just"
+" experimenting with the latest technologies, we invite you to submit your "
+"own demos to share with (or show off to) other web developers.</p> <p>Please"
+" complete the form below to ensure your demo is submitted to the Demo Studio"
+" successfully.</p>"
 msgstr ""
-"<p>Qoftë kur krijoni një rrugë të re të mahnitshme për të punuar në Web, qoftë kur është thjesht fjala për eksperimentim me teknologjitë e fjalës së fundit, ju ftojmë t’i parashtroni demot tuaja "
-"për t’i ndarë me (ose për t’ua treguar) zhvilluesve të tjerë web.</p> <p>Ju lutemi, plotësoni formularin më poshtë për t’u siguruar që demoja juaj parashtrohet me sukses te Studioja e Demove.</p>"
+"<p>Qoftë kur krijoni një rrugë të re të mahnitshme për të punuar në Web, "
+"qoftë kur është thjesht fjala për eksperimentim me teknologjitë e fjalës së "
+"fundit, ju ftojmë t’i parashtroni demot tuaja për t’i ndarë me (ose për t’ua"
+" treguar) zhvilluesve të tjerë web.</p> <p>Ju lutemi, plotësoni formularin "
+"më poshtë për t’u siguruar që demoja juaj parashtrohet me sukses te Studioja"
+" e Demove.</p>"
 
 #: kuma/demos/templates/demos/submit.html:72
 msgid "Describe Your Demo"
 msgstr "Përshkruani Demon Tuaj"
 
 #: kuma/demos/templates/demos/submit.html:74
-msgid "<p>Tell us more about your demo, including the name, description and the technologies used. Please list the browsers you have tested it with.</p>"
-msgstr "<p>Tregonani më tepër rreth demos suaj, përfshi këtu emrin, përshkrimin dhe teknologjitë e përdorura. Ju lutemi, radhisni shfletuesit me të cilët e keni vënë në provë.</p>"
+msgid ""
+"<p>Tell us more about your demo, including the name, description and the "
+"technologies used. Please list the browsers you have tested it with.</p>"
+msgstr ""
+"<p>Tregonani më tepër rreth demos suaj, përfshi këtu emrin, përshkrimin dhe "
+"teknologjitë e përdorura. Ju lutemi, radhisni shfletuesit me të cilët e keni"
+" vënë në provë.</p>"
 
 #: kuma/demos/templates/demos/submit.html:87
 msgid "Select up to five technologies used in your demo."
@@ -2274,38 +2739,65 @@ msgid "We support YouTube and Vimeo"
 msgstr "Mbulojmë YouTube-in dhe Vimeo-n"
 
 #: kuma/demos/templates/demos/submit.html:114
-msgid "If your demo has problems when displayed in an &lt;iframe&gt;, try changing this."
-msgstr "Nëse demoja juaj ka probleme kur shfaqet në një &lt;iframe&gt;, provoni të ndryshoni këtë."
+msgid ""
+"If your demo has problems when displayed in an &lt;iframe&gt;, try changing "
+"this."
+msgstr ""
+"Nëse demoja juaj ka probleme kur shfaqet në një &lt;iframe&gt;, provoni të "
+"ndryshoni këtë."
 
-#: kuma/demos/templates/demos/submit.html:119 kuma/demos/templates/demos/submit_noauth.html:48
+#: kuma/demos/templates/demos/submit.html:119
+#: kuma/demos/templates/demos/submit_noauth.html:48
 msgid "Preparing Your Demo"
 msgstr "Përgatitja e Demos Suaj"
 
 #: kuma/demos/templates/demos/submit.html:120
 #, python-format
 msgid ""
-"<ul> <li>Your demo's source code should be packaged inside a ZIP file.</li> <li>The main page of your demo should be a file named <code>index.html</code> in the root of the ZIP.</li> <li>Your demo "
-"should be built on client-side technology (HTML, CSS, JavaScript). Server-side languages like PHP and Ruby are not supported.</li> <li>If your demo requires external resources, it should use AJAX "
-"to access them.</li> <li>To submit your demo, you need an <a href=\"%(signup_url)s\">MDN profile</a>.</li> <li>Please identify in the demo details box any 3rd party content that can't be licensed "
-"under the CC-BY-SA license and include links to the authors' websites.</li> </ul>"
+"<ul> <li>Your demo's source code should be packaged inside a ZIP file.</li> "
+"<li>The main page of your demo should be a file named "
+"<code>index.html</code> in the root of the ZIP.</li> <li>Your demo should be"
+" built on client-side technology (HTML, CSS, JavaScript). Server-side "
+"languages like PHP and Ruby are not supported.</li> <li>If your demo "
+"requires external resources, it should use AJAX to access them.</li> <li>To "
+"submit your demo, you need an <a href=\"%(signup_url)s\">MDN "
+"profile</a>.</li> <li>Please identify in the demo details box any 3rd party "
+"content that can't be licensed under the CC-BY-SA license and include links "
+"to the authors' websites.</li> </ul>"
 msgstr ""
-"<ul> <li>Kodi burim i demos suaj duhet të paketohet brenda një kartele ZIP.</li> <li>Faqja kryesore e demos suaj duhet të jetë një kartele e quajtur <code>index.html</code>, në rrënjë të ZIP-it.</"
-"li> <li>Demoja juaj duhet krijuar me teknologji klienti (HTML, CSS, JavaScript). Gjuhët për shërbyes, të tilla si PHP dhe Ruby, s’mbulohen.</li> <li>Nëse demoja juaj lyp burime të jashtme, për "
-"hyrjen në to duhet të përdorë AJAX.</li> <li>Për parashtrimin e demos suaj keni nevojë për një <a href=\"%(signup_url)s\">profil te MDN-ja</a>.</li> <li>Ju lutemi, tregoni te kutia e hollësive të "
-"demos çfarëdo lënde palësh të treta që s’mund të licencohet sipas një licence CC-BY-SA dhe jepni lidhje për te sajtet e autorëve.</li> </ul>"
+"<ul> <li>Kodi burim i demos suaj duhet të paketohet brenda një kartele "
+"ZIP.</li> <li>Faqja kryesore e demos suaj duhet të jetë një kartele e "
+"quajtur <code>index.html</code>, në rrënjë të ZIP-it.</li> <li>Demoja juaj "
+"duhet krijuar me teknologji klienti (HTML, CSS, JavaScript). Gjuhët për "
+"shërbyes, të tilla si PHP dhe Ruby, s’mbulohen.</li> <li>Nëse demoja juaj "
+"lyp burime të jashtme, për hyrjen në to duhet të përdorë AJAX.</li> <li>Për "
+"parashtrimin e demos suaj keni nevojë për një <a "
+"href=\"%(signup_url)s\">profil te MDN-ja</a>.</li> <li>Ju lutemi, tregoni te"
+" kutia e hollësive të demos çfarëdo lënde palësh të treta që s’mund të "
+"licencohet sipas një licence CC-BY-SA dhe jepni lidhje për te sajtet e "
+"autorëve.</li> </ul>"
 
 #: kuma/demos/templates/demos/submit.html:133
 msgid "Provide the Source Code"
 msgstr "Jepni Kodin Burim"
 
 #: kuma/demos/templates/demos/submit.html:135
-msgid "<p>Upload a ZIP file of your source code, in which the main page of your demo is named <code>index.html</code> in the root directory.</p>"
-msgstr "<p>Ngarkoni një kartelë ZIP të kodit tuaj burim, e cila faqen kryesore të demos suaj nën emrin <code>index.html</code> ta përmbajë te drejtoria rrënjë.</p>"
+msgid ""
+"<p>Upload a ZIP file of your source code, in which the main page of your "
+"demo is named <code>index.html</code> in the root directory.</p>"
+msgstr ""
+"<p>Ngarkoni një kartelë ZIP të kodit tuaj burim, e cila faqen kryesore të "
+"demos suaj nën emrin <code>index.html</code> ta përmbajë te drejtoria "
+"rrënjë.</p>"
 
 #: kuma/demos/templates/demos/submit.html:162
 #, python-format
-msgid "I accept the <a href=\"%(terms_url)s#tfc\">Terms for Contributors</a> and <a href=\"%(terms_url)s#rrd\">Rights Representation Details</a>"
-msgstr "I pranoj <a href=\"%(terms_url)s#tfc\">Kushtet për Pjesëmarrësit</a> dhe <a href=\"%(terms_url)s#rrd\">Hollësitë mbi të Drejtat e Përfaqësimit</a>"
+msgid ""
+"I accept the <a href=\"%(terms_url)s#tfc\">Terms for Contributors</a> and <a"
+" href=\"%(terms_url)s#rrd\">Rights Representation Details</a>"
+msgstr ""
+"I pranoj <a href=\"%(terms_url)s#tfc\">Kushtet për Pjesëmarrësit</a> dhe <a "
+"href=\"%(terms_url)s#rrd\">Hollësitë mbi të Drejtat e Përfaqësimit</a>"
 
 #: kuma/demos/templates/demos/submit.html:177
 msgid "Submit demo"
@@ -2323,7 +2815,8 @@ msgstr "Hidhe Tej Demon"
 msgid "Save changes"
 msgstr "Ruaji ndryshimet"
 
-#: kuma/demos/templates/demos/submit.html:181 kuma/wiki/templates/wiki/includes/page_buttons.html:35
+#: kuma/demos/templates/demos/submit.html:181
+#: kuma/wiki/templates/wiki/includes/page_buttons.html:35
 msgid "Discard Changes"
 msgstr "Hidhi Tej Ndryshimet"
 
@@ -2333,11 +2826,14 @@ msgstr "Përditësoni Profilin Tuaj"
 
 #: kuma/demos/templates/demos/submit.html:190
 msgid ""
-"<p>Share your developer interests and areas of expertise with the MDN community. We'll be able to bring you a better, more customized experience and you will have a place to show off the amazing "
-"work you do.</p>"
+"<p>Share your developer interests and areas of expertise with the MDN "
+"community. We'll be able to bring you a better, more customized experience "
+"and you will have a place to show off the amazing work you do.</p>"
 msgstr ""
-"<p>Ndajini me bashkësinë MDN interesat tuaja si programues dhe fushat e ekspertizës. Do të jemi në gjendje t’ju ofrojmë një mjedis më të mirë, më të personalizuar dhe ju do të keni një vend ku të "
-"shpalosni punimet tuaja të mahnitshme.</p>"
+"<p>Ndajini me bashkësinë MDN interesat tuaja si programues dhe fushat e "
+"ekspertizës. Do të jemi në gjendje t’ju ofrojmë një mjedis më të mirë, më të"
+" personalizuar dhe ju do të keni një vend ku të shpalosni punimet tuaja të "
+"mahnitshme.</p>"
 
 #: kuma/demos/templates/demos/submit.html:195
 msgid "Go to your profile"
@@ -2345,11 +2841,14 @@ msgstr "Shkoni te profili juaj"
 
 #: kuma/demos/templates/demos/submit_noauth.html:27
 msgid ""
-"<p>Whether you are creating an amazing new way to experience the Web or just experimenting with the latest technologies, we invite you to submit your own demos to share with (or show off to) other "
-"web developers.</p>"
+"<p>Whether you are creating an amazing new way to experience the Web or just"
+" experimenting with the latest technologies, we invite you to submit your "
+"own demos to share with (or show off to) other web developers.</p>"
 msgstr ""
-"<p>Qoftë kur krijoni një rrugë të re të mahnitshme për të punuar në Web, qoftë kur thjesht është fjala për eksperimentim me teknologjitë e fjalës së fundit, ju ftojmë t’i parashtroni demot tuaja "
-"për t’i ndarë me (ose për t’ua treguar) zhvilluesve të tjerë web.</p>"
+"<p>Qoftë kur krijoni një rrugë të re të mahnitshme për të punuar në Web, "
+"qoftë kur thjesht është fjala për eksperimentim me teknologjitë e fjalës së "
+"fundit, ju ftojmë t’i parashtroni demot tuaja për t’i ndarë me (ose për t’ua"
+" treguar) zhvilluesve të tjerë web.</p>"
 
 #: kuma/demos/templates/demos/submit_noauth.html:36
 msgid "Before You Begin"
@@ -2357,30 +2856,54 @@ msgstr "Para Se të Filloni"
 
 #: kuma/demos/templates/demos/submit_noauth.html:37
 msgid ""
-"<ul> <li>You must be prepared to <strong>provide the source code</strong> for your demo. Demos are hosted on the Demo Studio's servers.</li> <li>Your demo's source code must be available under an "
-"<strong>open license</strong>, such as MPL, GPL, or BSD.</li> <li>Your demo should showcase <strong>open web technologies</strong>, such as HTML5 and CSS3.</li> <li>Your demo should support a wide "
-"range of <strong>modern web browsers</strong>, like Firefox, Chrome, Safari, and Opera.</li> </ul>"
+"<ul> <li>You must be prepared to <strong>provide the source code</strong> "
+"for your demo. Demos are hosted on the Demo Studio's servers.</li> <li>Your "
+"demo's source code must be available under an <strong>open license</strong>,"
+" such as MPL, GPL, or BSD.</li> <li>Your demo should showcase <strong>open "
+"web technologies</strong>, such as HTML5 and CSS3.</li> <li>Your demo should"
+" support a wide range of <strong>modern web browsers</strong>, like Firefox,"
+" Chrome, Safari, and Opera.</li> </ul>"
 msgstr ""
-"<ul> <li>Duhet të jeni gati për <strong>dhënien e kodit burim</strong> për demon tuaj. Demot strehohen te shërbyesit e Studios së Demove.</li> <li>Kodi burim i demos suaj duhet të jetë i passhëm "
-"sipas një <strong>lejeje të hapur</strong>, të tillë si MPL, GPL, ose BSD.</li> <li>Demoja juaj duhet të shpalosë <strong>teknologji web të hapura</strong>, të tilla si HTML5 dhe CSS3.</li> "
-"<li>Demoja juaj duhet të mbulojë një gamë të gjerë <strong>shfletuesish web modernë</strong>, të tillë si Firefox, Chrome, Safari, dhe Opera.</li> </ul>"
+"<ul> <li>Duhet të jeni gati për <strong>dhënien e kodit burim</strong> për "
+"demon tuaj. Demot strehohen te shërbyesit e Studios së Demove.</li> <li>Kodi"
+" burim i demos suaj duhet të jetë i passhëm sipas një <strong>lejeje të "
+"hapur</strong>, të tillë si MPL, GPL, ose BSD.</li> <li>Demoja juaj duhet të"
+" shpalosë <strong>teknologji web të hapura</strong>, të tilla si HTML5 dhe "
+"CSS3.</li> <li>Demoja juaj duhet të mbulojë një gamë të gjerë "
+"<strong>shfletuesish web modernë</strong>, të tillë si Firefox, Chrome, "
+"Safari, dhe Opera.</li> </ul>"
 
 #: kuma/demos/templates/demos/submit_noauth.html:49
 msgid ""
-"<ul> <li>Your demo's source code should be packaged inside a <strong>ZIP file</strong>.</li> <li>The main page of your demo should be a file named <strong><code>index.html</code></strong> in the "
-"root of the ZIP.</li> <li>Your demo should be built on <strong>client-side technology</strong> (HTML, CSS, JavaScript). Server-side languages like PHP and Ruby are not supported.</li> <li>If your "
-"demo requires external resources, it should use <strong>AJAX</strong> to access them.</li> <li>Please identify in the demo details box any 3rd party content that can't be licensed under the CC-BY-"
-"SA license and include links to the authors' websites.</li> </ul>"
+"<ul> <li>Your demo's source code should be packaged inside a <strong>ZIP "
+"file</strong>.</li> <li>The main page of your demo should be a file named "
+"<strong><code>index.html</code></strong> in the root of the ZIP.</li> "
+"<li>Your demo should be built on <strong>client-side technology</strong> "
+"(HTML, CSS, JavaScript). Server-side languages like PHP and Ruby are not "
+"supported.</li> <li>If your demo requires external resources, it should use "
+"<strong>AJAX</strong> to access them.</li> <li>Please identify in the demo "
+"details box any 3rd party content that can't be licensed under the CC-BY-SA "
+"license and include links to the authors' websites.</li> </ul>"
 msgstr ""
-"<ul> <li>Kodi burim i demos suaj duhet të jetë i paketuar si <strong>kartelë ZIP</strong>.</li> <li>Faqja kryesore e demos suaj duhet të jetë kartelë me emrin <strong><code>index.html</code></"
-"strong> në rrënjë të ZIP-it.</li> <li>Demoja juaj duhet të jetë e krijuar me <strong>teknologji për klient</strong> (HTML, CSS, JavaScript). Gjuhë shërbyesish, të tilla si PHP dhe Ruby, s’mbulohen."
-"</li> <li>Nëse demoja juaj lyp burime të jashtme, për hyrje në to do të duhej të përdorte <strong>AJAX</strong>-in.</li> <li>Ju lutemi, radhisni te kutiza e hollësive për demon çfarëdo lënde prej "
-"palësh të treta për të cilat s’vlen leja CC-BY-SA dhe përfshini lidhje për te sajtet përkatës.</li> </ul>"
+"<ul> <li>Kodi burim i demos suaj duhet të jetë i paketuar si <strong>kartelë"
+" ZIP</strong>.</li> <li>Faqja kryesore e demos suaj duhet të jetë kartelë me"
+" emrin <strong><code>index.html</code></strong> në rrënjë të ZIP-it.</li> "
+"<li>Demoja juaj duhet të jetë e krijuar me <strong>teknologji për "
+"klient</strong> (HTML, CSS, JavaScript). Gjuhë shërbyesish, të tilla si PHP "
+"dhe Ruby, s’mbulohen.</li> <li>Nëse demoja juaj lyp burime të jashtme, për "
+"hyrje në to do të duhej të përdorte <strong>AJAX</strong>-in.</li> <li>Ju "
+"lutemi, radhisni te kutiza e hollësive për demon çfarëdo lënde prej palësh "
+"të treta për të cilat s’vlen leja CC-BY-SA dhe përfshini lidhje për te "
+"sajtet përkatës.</li> </ul>"
 
 #: kuma/demos/templates/demos/submit_noauth.html:61
 #, python-format
-msgid "<p>To submit your demo, you need an <strong><a href=\"%(signup_url)s\">MDN profile</a></strong>.</p>"
-msgstr "<p>Që të parashtroni demon tuaj, keni nevojë për një <strong><a href=\"%(signup_url)s\">profil te MDN-ja</a></strong>.</p>"
+msgid ""
+"<p>To submit your demo, you need an <strong><a href=\"%(signup_url)s\">MDN "
+"profile</a></strong>.</p>"
+msgstr ""
+"<p>Që të parashtroni demon tuaj, keni nevojë për një <strong><a "
+"href=\"%(signup_url)s\">profil te MDN-ja</a></strong>.</p>"
 
 #: kuma/demos/templates/demos/submit_noauth.html:66
 msgid "Log In to Profile"
@@ -2398,18 +2921,30 @@ msgstr "Studio Demosh: Kushte për Kontribues"
 msgid "Rights Representation Details"
 msgstr "Hollësi të Drejtash Shfaqjeje"
 
-#: kuma/demos/templates/demos/elements/demos_head.html:31 kuma/demos/templates/demos/elements/search_form.html:4
+#: kuma/demos/templates/demos/elements/demos_head.html:31
+#: kuma/demos/templates/demos/elements/search_form.html:4
 msgid "Search the Demo Studio"
 msgstr "Kërkoni te Studioja e Demove"
 
-#: kuma/demos/templates/demos/elements/demos_head.html:33 kuma/demos/templates/demos/elements/search_form.html:6 kuma/landing/templates/landing/homepage.html:38
-#: kuma/landing/templates/landing/homepage.html:48 kuma/landing/templates/landing/homepage.html:55 kuma/landing/templates/landing/homepage.html:60 kuma/search/templates/search/base.html:2
-#: kuma/search/templates/search/results.html:15 kuma/search/templates/search/results.html:52 kuma/search/templates/search/results.html:55 kuma/search/templates/search/results.html:60
-#: templates/base.html:180 templates/base.html:181 templates/base.html:183 templates/includes/common_macros.html:26 templates/includes/common_macros.html:27
+#: kuma/demos/templates/demos/elements/demos_head.html:33
+#: kuma/demos/templates/demos/elements/search_form.html:6
+#: kuma/landing/templates/landing/homepage.html:38
+#: kuma/landing/templates/landing/homepage.html:48
+#: kuma/landing/templates/landing/homepage.html:55
+#: kuma/landing/templates/landing/homepage.html:60
+#: kuma/search/templates/search/base.html:2
+#: kuma/search/templates/search/results.html:15
+#: kuma/search/templates/search/results.html:52
+#: kuma/search/templates/search/results.html:55
+#: kuma/search/templates/search/results.html:60 templates/base.html:180
+#: templates/base.html:181 templates/base.html:183
+#: templates/includes/common_macros.html:26
+#: templates/includes/common_macros.html:27
 msgid "Search"
 msgstr "Kërkoni"
 
-#: kuma/demos/templates/demos/elements/submission_creator.html:2 kuma/demos/templates/demos/elements/user_link.html:2
+#: kuma/demos/templates/demos/elements/submission_creator.html:2
+#: kuma/demos/templates/demos/elements/user_link.html:2
 #, python-format
 msgid "See %(display_name)s's profile"
 msgstr "Shihni profilin për %(display_name)s"
@@ -2503,22 +3038,31 @@ msgid "Launch %(title)s"
 msgstr "Nise %(title)s"
 
 #: kuma/landing/templates/landing/fellowship.html:12
-msgid "The Mozilla Developer Network (MDN) Fellowship Program invites world-class web developers to come change the world with Mozilla."
-msgstr "Programi Mozilla Developer Network (MDN) Fellowship fton programues web të klasit botëror të vijnë e të ndryshojnë botën me Mozilla-n."
+msgid ""
+"The Mozilla Developer Network (MDN) Fellowship Program invites world-class "
+"web developers to come change the world with Mozilla."
+msgstr ""
+"Programi Mozilla Developer Network (MDN) Fellowship fton programues web të "
+"klasit botëror të vijnë e të ndryshojnë botën me Mozilla-n."
 
 #: kuma/landing/templates/landing/homepage.html:14
 msgid ""
-"The Mozilla Developer Network (MDN) provides information about Open Web technologies including HTML, CSS, and APIs for both Web sites and HTML5 Apps. It also documents Mozilla products, like "
-"Firefox OS."
+"The Mozilla Developer Network (MDN) provides information about Open Web "
+"technologies including HTML, CSS, and APIs for both Web sites and HTML5 "
+"Apps. It also documents Mozilla products, like Firefox OS."
 msgstr ""
-"Rrjeti i Zhvilluesve Mozilla (Mozilla Developer Network - MDN) ofron informacion mbi teknologji për Web të Hapur, përfshi HTML, CSS, dhe API sajtesh dhe Aplikacione HTML5. Në të dokumentohen "
-"gjithashtu edhe produkte Mozilla, të tillë si Firefox OS."
+"Rrjeti i Zhvilluesve Mozilla (Mozilla Developer Network - MDN) ofron "
+"informacion mbi teknologji për Web të Hapur, përfshi HTML, CSS, dhe API "
+"sajtesh dhe Aplikacione HTML5. Në të dokumentohen gjithashtu edhe produkte "
+"Mozilla, të tillë si Firefox OS."
 
 #: kuma/landing/templates/landing/homepage.html:32
 msgid "Shared knowledge <span>for the Open Web</span>"
 msgstr "Dije e përbashkët <span>për Web-in e Hapur</span>"
 
-#: kuma/landing/templates/landing/homepage.html:42 kuma/landing/templates/landing/homepage.html:59 kuma/search/templates/search/results.html:59
+#: kuma/landing/templates/landing/homepage.html:42
+#: kuma/landing/templates/landing/homepage.html:59
+#: kuma/search/templates/search/results.html:59
 msgid "Search the docs"
 msgstr "Kërko në dokumente"
 
@@ -2538,7 +3082,8 @@ msgstr "Platformë<br />Web"
 msgid "Web APIs &amp; DOM"
 msgstr "API Web &amp; DOM"
 
-#: kuma/landing/templates/landing/homepage.html:75 kuma/landing/templates/landing/homepage.html:95
+#: kuma/landing/templates/landing/homepage.html:75
+#: kuma/landing/templates/landing/homepage.html:95
 msgid "more..."
 msgstr "më tepër..."
 
@@ -2579,8 +3124,12 @@ msgid "Connect"
 msgstr "Lidhu"
 
 #: kuma/landing/templates/landing/homepage.html:100
-msgid "Get Web technology news from Mozilla, get help from other developers, and more!"
-msgstr "Merrni lajme mbi teknologjitë Web nga Mozilla, merrni ndihmë nga programues të tjerë, dhe të tjera!"
+msgid ""
+"Get Web technology news from Mozilla, get help from other developers, and "
+"more!"
+msgstr ""
+"Merrni lajme mbi teknologjitë Web nga Mozilla, merrni ndihmë nga programues "
+"të tjerë, dhe të tjera!"
 
 #: kuma/landing/templates/landing/homepage.html:101
 msgid "Learn more and sign up!"
@@ -2607,8 +3156,12 @@ msgid "Build Open Web Apps"
 msgstr "Krijoni Aplikacione Web të Hapura"
 
 #: kuma/landing/templates/landing/homepage.html:133
-msgid "<a href=\"http://hacks.mozilla.org\">read more at hacks.mozilla.org <i aria-hidden=\"true\" class=\"icon-arrow-right\"></i></a></span>"
-msgstr "<a href=\"http://hacks.mozilla.org\">lexoni më tepër te hacks.mozilla.org <i aria-hidden=\"true\" class=\"icon-arrow-right\"></i></a></span>"
+msgid ""
+"<a href=\"http://hacks.mozilla.org\">read more at hacks.mozilla.org <i aria-"
+"hidden=\"true\" class=\"icon-arrow-right\"></i></a></span>"
+msgstr ""
+"<a href=\"http://hacks.mozilla.org\">lexoni më tepër te hacks.mozilla.org <i"
+" aria-hidden=\"true\" class=\"icon-arrow-right\"></i></a></span>"
 
 #: kuma/landing/templates/landing/homepage.html:138
 msgid "Get Involved"
@@ -2617,19 +3170,29 @@ msgstr "Përfshihuni"
 #: kuma/landing/templates/landing/homepage.html:140
 #, python-format
 msgid ""
-"<p class=\"numbers\"> <span class=\"row1\">Join <span class=\"number\">%(contributors)s</span> contributors</span> <span class=\"row2\">in <span class=\"number\">%(locales)s</span> languages and "
+"<p class=\"numbers\"> <span class=\"row1\">Join <span "
+"class=\"number\">%(contributors)s</span> contributors</span> <span "
+"class=\"row2\">in <span class=\"number\">%(locales)s</span> languages and "
 "locales</span> <span class=\"row3\">around the world.</span> </p>"
 msgstr ""
-"<p class=\"numbers\"> <span class=\"row1\">Bashkojuni <span class=\"number\">%(contributors)s</span> kontribuesve</span> <span class=\"row2\">nga <span class=\"number\">%(locales)s</span> gjuhë dhe "
+"<p class=\"numbers\"> <span class=\"row1\">Bashkojuni <span "
+"class=\"number\">%(contributors)s</span> kontribuesve</span> <span "
+"class=\"row2\">nga <span class=\"number\">%(locales)s</span> gjuhë dhe "
 "vendore</span> <span class=\"row3\">anembanë botës.</span> </p>"
 
-#: kuma/landing/templates/landing/homepage.html:147 kuma/landing/templates/landing/homepage.html:154
+#: kuma/landing/templates/landing/homepage.html:147
+#: kuma/landing/templates/landing/homepage.html:154
 msgid "Help improve MDN"
 msgstr "Ndihmoni të përmirësohet MDN-ja"
 
 #: kuma/landing/templates/landing/homepage.html:158
-msgid "All parts of MDN (docs, demos, and the site itself) are created by an open community of developers. Please join us! Pick one of these ways to help:"
-msgstr "Krejt pjesët e MDN-së (dokumente, demo, dhe vetë sajti) janë krijuar nga një bashkësi e hapur programuesish. Ju lutemi, bëhuni pjesë e jona! Zgjidhni një nga këto rrugët për të na ndihmuar:"
+msgid ""
+"All parts of MDN (docs, demos, and the site itself) are created by an open "
+"community of developers. Please join us! Pick one of these ways to help:"
+msgstr ""
+"Krejt pjesët e MDN-së (dokumente, demo, dhe vetë sajti) janë krijuar nga një"
+" bashkësi e hapur programuesish. Ju lutemi, bëhuni pjesë e jona! Zgjidhni "
+"një nga këto rrugët për të na ndihmuar:"
 
 #: kuma/landing/templates/landing/homepage.html:164
 msgid "Getting started"
@@ -2660,7 +3223,8 @@ msgstr "Si të kontribuohet te kodi bazë i MDN-së"
 msgid "Posted %(entrydate)s by %(authorlink)s"
 msgstr "Postuar më %(entrydate)s nga %(authorlink)s"
 
-#: kuma/landing/templates/landing/promote_buttons.html:5 kuma/landing/templates/landing/promote_buttons.html:17
+#: kuma/landing/templates/landing/promote_buttons.html:5
+#: kuma/landing/templates/landing/promote_buttons.html:17
 msgid "Promote MDN"
 msgstr "Promuovoni MDN-në"
 
@@ -2670,13 +3234,21 @@ msgstr "Jepni ca përkujdesje zhvilluesi."
 
 #: kuma/landing/templates/landing/promote_buttons.html:20
 msgid ""
-"<ol> <li><strong>Get Buttons:</strong> Use our simple form below to create a custom button and source code to promote MDN on your website or blog.</li> <li><strong>Post Buttons:</strong> Copy the "
-"source code and paste it anywhere on your website or blog to help people click through to MDN.</li> <li><strong>Feel Good:</strong> Take pride in knowing you're making developers lives just a "
-"little bit better by sharing MDN with the world.</li> </ol>"
+"<ol> <li><strong>Get Buttons:</strong> Use our simple form below to create a"
+" custom button and source code to promote MDN on your website or blog.</li> "
+"<li><strong>Post Buttons:</strong> Copy the source code and paste it "
+"anywhere on your website or blog to help people click through to MDN.</li> "
+"<li><strong>Feel Good:</strong> Take pride in knowing you're making "
+"developers lives just a little bit better by sharing MDN with the "
+"world.</li> </ol>"
 msgstr ""
-"<ol> <li><strong>Merrni Butona:</strong> Përdorni formularin tonë të thjeshtë të mëposhtëm, për të krijuar butona të personalizuar dhe kod burim që të promovoni MDN-në në sajtin ose blogun tuaj.</"
-"li> <li><strong>Butona Dërgimi:</strong> Kopjojeni kodin burim dhe hidheni në çfarëdo pjese të sajtit ose blogut tuaj që të ndihmoni njerëzit të shkojnë tek sajti MDN.</li> <li><strong>Kënaquni:</"
-"strong> Ndihuni krenar që po ndihmoni sadopak programuesit përmes promuovimit të MDN-së gjithandej.</li> </ol>"
+"<ol> <li><strong>Merrni Butona:</strong> Përdorni formularin tonë të "
+"thjeshtë të mëposhtëm, për të krijuar butona të personalizuar dhe kod burim "
+"që të promovoni MDN-në në sajtin ose blogun tuaj.</li> <li><strong>Butona "
+"Dërgimi:</strong> Kopjojeni kodin burim dhe hidheni në çfarëdo pjese të "
+"sajtit ose blogut tuaj që të ndihmoni njerëzit të shkojnë tek sajti "
+"MDN.</li> <li><strong>Kënaquni:</strong> Ndihuni krenar që po ndihmoni "
+"sadopak programuesit përmes promuovimit të MDN-së gjithandej.</li> </ol>"
 
 #: kuma/landing/templates/landing/promote_buttons.html:35
 msgid "Preview"
@@ -2734,57 +3306,93 @@ msgstr "Kodi burim për ju:"
 msgid "Your button will take people to:"
 msgstr "Butoni juaj do t’i shpjerë vizitorët te:"
 
-#: kuma/landing/templates/landing/promote_buttons.html:162 kuma/landing/templates/landing/promote_buttons.html:166 kuma/landing/templates/landing/promote_buttons.html:170
+#: kuma/landing/templates/landing/promote_buttons.html:162
+#: kuma/landing/templates/landing/promote_buttons.html:166
+#: kuma/landing/templates/landing/promote_buttons.html:170
 msgid "Better CSS docs for a better Web on MDN"
 msgstr "Dokumentim më i mirë i CSS-së në MDN për një Web më të mirë"
 
-#: kuma/landing/templates/landing/promote_buttons.html:163 kuma/landing/templates/landing/promote_buttons.html:167 kuma/landing/templates/landing/promote_buttons.html:171
+#: kuma/landing/templates/landing/promote_buttons.html:163
+#: kuma/landing/templates/landing/promote_buttons.html:167
+#: kuma/landing/templates/landing/promote_buttons.html:171
 msgid "Better HTML docs for a better Web on MDN"
 msgstr "Dokumentim më i mirë i HTML-së në MDN për një Web më të mirë"
 
-#: kuma/landing/templates/landing/promote_buttons.html:164 kuma/landing/templates/landing/promote_buttons.html:168 kuma/landing/templates/landing/promote_buttons.html:172
+#: kuma/landing/templates/landing/promote_buttons.html:164
+#: kuma/landing/templates/landing/promote_buttons.html:168
+#: kuma/landing/templates/landing/promote_buttons.html:172
 msgid "Better JavaScript docs for a better Web on MDN"
 msgstr "Dokumentim më i mirë i Javascript-it në MDN për një Web më të mirë"
 
-#: kuma/landing/templates/landing/promote_buttons.html:165 kuma/landing/templates/landing/promote_buttons.html:169 kuma/landing/templates/landing/promote_buttons.html:173
+#: kuma/landing/templates/landing/promote_buttons.html:165
+#: kuma/landing/templates/landing/promote_buttons.html:169
+#: kuma/landing/templates/landing/promote_buttons.html:173
 msgid "Better Web docs for a better Web on MDN"
 msgstr "Dokumentim më i mirë i Web-it në MDN për një Web më të mirë"
 
-#: kuma/landing/templates/landing/promote_buttons.html:174 kuma/landing/templates/landing/promote_buttons.html:178 kuma/landing/templates/landing/promote_buttons.html:182
+#: kuma/landing/templates/landing/promote_buttons.html:174
+#: kuma/landing/templates/landing/promote_buttons.html:178
+#: kuma/landing/templates/landing/promote_buttons.html:182
 msgid "MDN is Developer Powered for CSS docs, demos and more."
-msgstr "MDN-ja për dokumentim CSS-je, demo dhe të tjera Mbështetet te Zhvilluesit."
+msgstr ""
+"MDN-ja për dokumentim CSS-je, demo dhe të tjera Mbështetet te Zhvilluesit."
 
-#: kuma/landing/templates/landing/promote_buttons.html:175 kuma/landing/templates/landing/promote_buttons.html:179 kuma/landing/templates/landing/promote_buttons.html:183
+#: kuma/landing/templates/landing/promote_buttons.html:175
+#: kuma/landing/templates/landing/promote_buttons.html:179
+#: kuma/landing/templates/landing/promote_buttons.html:183
 msgid "MDN is Developer Powered for HTML docs, demos and more."
-msgstr "MDN-ja për dokumentim HTML-je, demo dhe të tjera Mbështetet te Zhvilluesit."
+msgstr ""
+"MDN-ja për dokumentim HTML-je, demo dhe të tjera Mbështetet te Zhvilluesit."
 
-#: kuma/landing/templates/landing/promote_buttons.html:176 kuma/landing/templates/landing/promote_buttons.html:180 kuma/landing/templates/landing/promote_buttons.html:184
+#: kuma/landing/templates/landing/promote_buttons.html:176
+#: kuma/landing/templates/landing/promote_buttons.html:180
+#: kuma/landing/templates/landing/promote_buttons.html:184
 msgid "MDN is Developer Powered for JavaScript docs, demos and more."
-msgstr "MDN-ja për dokumentim JavaScript-i, demo dhe të tjera Mbështetet te Zhvilluesit."
+msgstr ""
+"MDN-ja për dokumentim JavaScript-i, demo dhe të tjera Mbështetet te "
+"Zhvilluesit."
 
-#: kuma/landing/templates/landing/promote_buttons.html:177 kuma/landing/templates/landing/promote_buttons.html:181 kuma/landing/templates/landing/promote_buttons.html:185
+#: kuma/landing/templates/landing/promote_buttons.html:177
+#: kuma/landing/templates/landing/promote_buttons.html:181
+#: kuma/landing/templates/landing/promote_buttons.html:185
 msgid "MDN is Developer Powered for Web docs, demos and more."
-msgstr "MDN-ja për dokumentim Web-i, demo dhe të tjera Mbështetet te Zhvilluesit."
+msgstr ""
+"MDN-ja për dokumentim Web-i, demo dhe të tjera Mbështetet te Zhvilluesit."
 
-#: kuma/landing/templates/landing/promote_buttons.html:186 kuma/landing/templates/landing/promote_buttons.html:190 kuma/landing/templates/landing/promote_buttons.html:194
+#: kuma/landing/templates/landing/promote_buttons.html:186
+#: kuma/landing/templates/landing/promote_buttons.html:190
+#: kuma/landing/templates/landing/promote_buttons.html:194
 msgid "CSS docs by developers, for developers on MDN"
 msgstr "Dokumente CSS nga zhvilluesit, për zhvilluesit në MDN"
 
-#: kuma/landing/templates/landing/promote_buttons.html:187 kuma/landing/templates/landing/promote_buttons.html:191 kuma/landing/templates/landing/promote_buttons.html:195
+#: kuma/landing/templates/landing/promote_buttons.html:187
+#: kuma/landing/templates/landing/promote_buttons.html:191
+#: kuma/landing/templates/landing/promote_buttons.html:195
 msgid "HTML docs by developers, for developers on MDN"
 msgstr "Dokumente HTML nga zhvilluesit, për zhvilluesit në MDN"
 
-#: kuma/landing/templates/landing/promote_buttons.html:188 kuma/landing/templates/landing/promote_buttons.html:192 kuma/landing/templates/landing/promote_buttons.html:196
+#: kuma/landing/templates/landing/promote_buttons.html:188
+#: kuma/landing/templates/landing/promote_buttons.html:192
+#: kuma/landing/templates/landing/promote_buttons.html:196
 msgid "JavaScript docs by developers, for developers on MDN"
 msgstr "Dokumente JavaScript nga zhvilluesit, për zhvilluesit në MDN"
 
-#: kuma/landing/templates/landing/promote_buttons.html:189 kuma/landing/templates/landing/promote_buttons.html:193 kuma/landing/templates/landing/promote_buttons.html:197
+#: kuma/landing/templates/landing/promote_buttons.html:189
+#: kuma/landing/templates/landing/promote_buttons.html:193
+#: kuma/landing/templates/landing/promote_buttons.html:197
 msgid "Web docs by developers, for developers on MDN"
 msgstr "Dokumente Web nga zhvillues, për zhvillues në MDN"
 
-#: kuma/landing/templates/landing/promote_buttons.html:198 kuma/landing/templates/landing/promote_buttons.html:199 kuma/landing/templates/landing/promote_buttons.html:200
-msgid "MDN is your Web Developer Toolbox for docs, demos and more on HTML, CSS, JavaScript and other Web standards and open technologies."
-msgstr "MDN është Laboratori juaj i Programimit Web, me dokumente, demo dhe të tjera gjëra për HTML-në, CSS-në, JavaScript-in dhe të tjera standarde Web dhe teknologji të hapura."
+#: kuma/landing/templates/landing/promote_buttons.html:198
+#: kuma/landing/templates/landing/promote_buttons.html:199
+#: kuma/landing/templates/landing/promote_buttons.html:200
+msgid ""
+"MDN is your Web Developer Toolbox for docs, demos and more on HTML, CSS, "
+"JavaScript and other Web standards and open technologies."
+msgstr ""
+"MDN është Laboratori juaj i Programimit Web, me dokumente, demo dhe të tjera"
+" gjëra për HTML-në, CSS-në, JavaScript-in dhe të tjera standarde Web dhe "
+"teknologji të hapura."
 
 #: kuma/search/admin.py:11
 msgid "Can't promote more than one index at once."
@@ -2804,8 +3412,12 @@ msgid "Can't demote more than one index at once."
 msgstr "S’mund të ulet në klasifikim më shumë se një tregues në herë."
 
 #: kuma/search/admin.py:24
-msgid "Can't demote the index if there is only one. Create and populate a new one first."
-msgstr "S’mund te ulet në klasifikim treguesi, nëse ka vetëm një të tillë. Fillimisht krijoni dhe populloni një të ri."
+msgid ""
+"Can't demote the index if there is only one. Create and populate a new one "
+"first."
+msgstr ""
+"S’mund te ulet në klasifikim treguesi, nëse ka vetëm një të tillë. "
+"Fillimisht krijoni dhe populloni një të ri."
 
 #: kuma/search/admin.py:29
 #, python-format
@@ -2814,7 +3426,9 @@ msgstr "U ul në klasifikim treguesi i kërkimeve %s."
 
 #: kuma/search/admin.py:30
 msgid "Demote selected search index (automatic fallback to previous index)"
-msgstr "Ule në klafisikim treguesin e përzgjedhur të kërkimeve (rikthim i vetvetishëm te treguesi i mëparshëm)"
+msgstr ""
+"Ule në klafisikim treguesin e përzgjedhur të kërkimeve (rikthim i "
+"vetvetishëm te treguesi i mëparshëm)"
 
 #: kuma/search/admin.py:37
 msgid "Can't populate more than one index at once."
@@ -2835,11 +3449,17 @@ msgstr "Ka tashmë një pasues për treguesin e tanishëm %s"
 
 #: kuma/search/utils.py:14
 msgid "Search is temporarily unavailable. Please try again in a few minutes."
-msgstr "Kërkimi është përkohësisht i pamundur. Ju lutemi, riprovoni pas pak minutash."
+msgstr ""
+"Kërkimi është përkohësisht i pamundur. Ju lutemi, riprovoni pas pak "
+"minutash."
 
 #: kuma/search/utils.py:17
-msgid "Something went wrong with the search query. Please try again in a few minutes."
-msgstr "Diçka shkoi ters me kërkesën për kërkim. Ju lutemi, riprovoni pas pak minutash."
+msgid ""
+"Something went wrong with the search query. Please try again in a few "
+"minutes."
+msgstr ""
+"Diçka shkoi ters me kërkesën për kërkim. Ju lutemi, riprovoni pas pak "
+"minutash."
 
 #: kuma/search/views.py:95
 msgid "name"
@@ -2865,8 +3485,12 @@ msgstr "Përfundime Kërkimi për \"%(query)s\""
 
 #: kuma/search/templates/search/results.html:39
 #, python-format
-msgid "translated from <a href=\"%(parent_url)s\" title=\"%(parent_title)s\">%(parent_title)s (%(parent_language)s)</a>"
-msgstr "përkthyer nga <a href=\"%(parent_url)s\" title=\"%(parent_title)s\">%(parent_title)s (%(parent_language)s)</a>"
+msgid ""
+"translated from <a href=\"%(parent_url)s\" "
+"title=\"%(parent_title)s\">%(parent_title)s (%(parent_language)s)</a>"
+msgstr ""
+"përkthyer nga <a href=\"%(parent_url)s\" "
+"title=\"%(parent_title)s\">%(parent_title)s (%(parent_language)s)</a>"
 
 #: kuma/search/templates/search/results.html:51
 msgid "MDN Site Search"
@@ -2885,10 +3509,18 @@ msgstr[1] "U gjetën %(count)s dokumente për \"%(query)s\" në %(locale_native)
 
 #: kuma/search/templates/search/results.html:80
 #, python-format
-msgid "%(count)s document found for \"%(query)s\" in %(locale_native)s and %(default_locale_native)s."
-msgid_plural "%(count)s documents found for \"%(query)s\" in %(locale_native)s and %(default_locale_native)s."
-msgstr[0] "U gjet %(count)s dokument për \"%(query)s\" në %(locale_native)s dhe %(default_locale_native)s."
-msgstr[1] "U gjet %(count)s dokumente për \"%(query)s\" në %(locale_native)s dhe %(default_locale_native)s."
+msgid ""
+"%(count)s document found for \"%(query)s\" in %(locale_native)s and "
+"%(default_locale_native)s."
+msgid_plural ""
+"%(count)s documents found for \"%(query)s\" in %(locale_native)s and "
+"%(default_locale_native)s."
+msgstr[0] ""
+"U gjet %(count)s dokument për \"%(query)s\" në %(locale_native)s dhe "
+"%(default_locale_native)s."
+msgstr[1] ""
+"U gjet %(count)s dokumente për \"%(query)s\" në %(locale_native)s dhe "
+"%(default_locale_native)s."
 
 #: kuma/search/templates/search/results.html:88
 #, python-format
@@ -2899,10 +3531,17 @@ msgstr[1] "U gjetën %(count)s dokumente në %(locale_native)s."
 
 #: kuma/search/templates/search/results.html:94
 #, python-format
-msgid "%(count)s document found in %(locale_native)s and %(default_locale_native)s."
-msgid_plural "%(count)s documents found in %(locale_native)s and %(default_locale_native)s."
-msgstr[0] "U gjet %(count)s dokument në %(locale_native)s dhe %(default_locale_native)s."
-msgstr[1] "U gjetën %(count)s dokumente në %(locale_native)s dhe %(default_locale_native)s."
+msgid ""
+"%(count)s document found in %(locale_native)s and %(default_locale_native)s."
+msgid_plural ""
+"%(count)s documents found in %(locale_native)s and "
+"%(default_locale_native)s."
+msgstr[0] ""
+"U gjet %(count)s dokument në %(locale_native)s dhe "
+"%(default_locale_native)s."
+msgstr[1] ""
+"U gjetën %(count)s dokumente në %(locale_native)s dhe "
+"%(default_locale_native)s."
 
 #: kuma/search/templates/search/results.html:104
 #, python-format
@@ -2951,11 +3590,14 @@ msgstr "u krijua"
 #: kuma/users/adapters.py:17
 #, python-format
 msgid ""
-"Sorry, you must have at least one connected account so you can sign in. To disconnect this account connect a different one first. To delete your MDN profile please <a href=\"%(bug_form_url)s\" rel="
-"\"nofollow\">file a bug</a>."
+"Sorry, you must have at least one connected account so you can sign in. To "
+"disconnect this account connect a different one first. To delete your MDN "
+"profile please <a href=\"%(bug_form_url)s\" rel=\"nofollow\">file a bug</a>."
 msgstr ""
-"Na ndjeni, duhet të keni të paktën një llogari të lidhur që të mund të bëni hyrjen. Për të shkëputur këtë llogari, lidhuni së pari me një tjetër. Që të fshini profilin tuaj MDN, ju lutemi, <a href="
-"\"%(bug_form_url)s\" rel=\"nofollow\">depozitoni një kërkesë</a>."
+"Na ndjeni, duhet të keni të paktën një llogari të lidhur që të mund të bëni "
+"hyrjen. Për të shkëputur këtë llogari, lidhuni së pari me një tjetër. Që të "
+"fshini profilin tuaj MDN, ju lutemi, <a href=\"%(bug_form_url)s\" "
+"rel=\"nofollow\">depozitoni një kërkesë</a>."
 
 #: kuma/users/adapters.py:21
 msgid "An email address cannot be used as a username."
@@ -2971,7 +3613,9 @@ msgstr "Përdorues"
 
 #: kuma/users/apps.py:69
 #, python-format
-msgid "You have completed the first step of <a href=\"%s\">getting started with MDN</a>"
+msgid ""
+"You have completed the first step of <a href=\"%s\">getting started with "
+"MDN</a>"
 msgstr "Plotësuat hapin e parë se <a href=\"%s\">si t’ia fillohet me MDN-në</a>"
 
 #: kuma/users/backends.py:32
@@ -2987,8 +3631,11 @@ msgid "hash"
 msgstr "hash"
 
 #: kuma/users/constants.py:6
-msgid "Username may contain only letters, numbers, and these characters: . - _ +"
-msgstr "Emri i përdoruesit mund të përmbajë vetëm shkronja, numra dhe këto shenja: . - _ +"
+msgid ""
+"Username may contain only letters, numbers, and these characters: . - _ +"
+msgstr ""
+"Emri i përdoruesit mund të përmbajë vetëm shkronja, numra dhe këto shenja: ."
+" - _ +"
 
 #: kuma/users/forms.py:23
 msgid "You must agree to the privacy policy."
@@ -3034,31 +3681,42 @@ msgstr "Fushë Ekspertize"
 msgid "Username"
 msgstr "Emër përdoruesi"
 
-#: kuma/users/forms.py:180 kuma/users/models.py:139 kuma/users/templates/users/user_detail.html:117
+#: kuma/users/forms.py:180 kuma/users/models.py:139
+#: kuma/users/templates/users/user_detail.html:117
 msgid "Website"
 msgstr "Sajt"
 
-#: kuma/users/forms.py:189 kuma/users/models.py:154 kuma/users/templates/users/user_detail.html:121 kuma/wiki/templates/wiki/includes/document_macros.html:109
+#: kuma/users/forms.py:189 kuma/users/models.py:154
+#: kuma/users/templates/users/user_detail.html:121
+#: kuma/wiki/templates/wiki/includes/document_macros.html:109
 msgid "Twitter"
 msgstr "Twitter"
 
-#: kuma/users/forms.py:198 kuma/users/models.py:149 kuma/users/templates/users/user_detail.html:126 kuma/users/templates/users/user_detail.html:130 templates/includes/login.html:21
+#: kuma/users/forms.py:198 kuma/users/models.py:149
+#: kuma/users/templates/users/user_detail.html:126
+#: kuma/users/templates/users/user_detail.html:130
+#: templates/includes/login.html:21
 msgid "GitHub"
 msgstr "Github"
 
-#: kuma/users/forms.py:207 kuma/users/models.py:169 kuma/users/templates/users/user_detail.html:135
+#: kuma/users/forms.py:207 kuma/users/models.py:169
+#: kuma/users/templates/users/user_detail.html:135
 msgid "Stack Overflow"
 msgstr "Stack Overflow"
 
-#: kuma/users/forms.py:216 kuma/users/models.py:159 kuma/users/templates/users/user_detail.html:139
+#: kuma/users/forms.py:216 kuma/users/models.py:159
+#: kuma/users/templates/users/user_detail.html:139
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: kuma/users/forms.py:225 kuma/users/models.py:144 kuma/users/templates/users/user_detail.html:143
+#: kuma/users/forms.py:225 kuma/users/models.py:144
+#: kuma/users/templates/users/user_detail.html:143
 msgid "Mozillians"
 msgstr "Moxillianë"
 
-#: kuma/users/forms.py:234 kuma/users/models.py:164 kuma/users/templates/users/user_detail.html:147 kuma/wiki/templates/wiki/includes/document_macros.html:110
+#: kuma/users/forms.py:234 kuma/users/models.py:164
+#: kuma/users/templates/users/user_detail.html:147
+#: kuma/wiki/templates/wiki/includes/document_macros.html:110
 msgid "Facebook"
 msgstr "Facebook"
 
@@ -3112,8 +3770,12 @@ msgid "Homepage"
 msgstr "Faqe Hyrëse"
 
 #: kuma/users/models.py:60
-msgid "This URL has an invalid format. Valid URLs look like http://example.com/my_page."
-msgstr "Kjo URL ka format të pavlefshëm. URL-të e vlefshme kanë pamje si kjo http://shembull.com/faqja_ime."
+msgid ""
+"This URL has an invalid format. Valid URLs look like "
+"http://example.com/my_page."
+msgstr ""
+"Kjo URL ka format të pavlefshëm. URL-të e vlefshme kanë pamje si kjo "
+"http://shembull.com/faqja_ime."
 
 #: kuma/users/models.py:70
 msgid "Name"
@@ -3135,7 +3797,10 @@ msgstr "Rreth Meje"
 msgid "IRC nickname"
 msgstr "Nofkë IRC"
 
-#: kuma/users/models.py:94 kuma/wiki/templates/wiki/confirm_revision_revert.html:27 kuma/wiki/templates/wiki/create.html:79 kuma/wiki/templates/wiki/edit.html:188
+#: kuma/users/models.py:94
+#: kuma/wiki/templates/wiki/confirm_revision_revert.html:27
+#: kuma/wiki/templates/wiki/create.html:79
+#: kuma/wiki/templates/wiki/edit.html:188
 msgid "Tags"
 msgstr "Etiketa"
 
@@ -3173,13 +3838,21 @@ msgstr "Emri i përdoruesit është i domosdoshëm."
 
 #: kuma/users/signup.py:8
 #, python-format
-msgid "Username is too short (%(show_value)s characters). It must be at least %(limit_value)s characters."
-msgstr "Emri i përdoruesit është shumë i shkurtër (%(show_value)s shenja). Duhet të jetë të paktën %(limit_value)s shenja."
+msgid ""
+"Username is too short (%(show_value)s characters). It must be at least "
+"%(limit_value)s characters."
+msgstr ""
+"Emri i përdoruesit është shumë i shkurtër (%(show_value)s shenja). Duhet të "
+"jetë të paktën %(limit_value)s shenja."
 
 #: kuma/users/signup.py:10
 #, python-format
-msgid "Username is too long (%(show_value)s characters). It must be %(limit_value)s characters or less."
-msgstr "Emri i përdoruesit është shumë i gjatë (%(show_value)s shenja). Duhet të jetë %(limit_value)s ose më pak shenja."
+msgid ""
+"Username is too long (%(show_value)s characters). It must be %(limit_value)s"
+" characters or less."
+msgstr ""
+"Emri i përdoruesit është shumë i gjatë (%(show_value)s shenja). Duhet të "
+"jetë %(limit_value)s ose më pak shenja."
 
 #: kuma/users/signup.py:13
 msgid "You must agree to the terms of use."
@@ -3207,7 +3880,8 @@ msgstr "%(email)s I paverifikuar"
 msgid "Other:"
 msgstr "Tjetër:"
 
-#: kuma/users/templates/account/account_inactive.html:3 kuma/users/templates/account/account_inactive.html:7
+#: kuma/users/templates/account/account_inactive.html:3
+#: kuma/users/templates/account/account_inactive.html:7
 msgid "Profile Inactive"
 msgstr "Profil Joaktiv"
 
@@ -3215,7 +3889,9 @@ msgstr "Profil Joaktiv"
 msgid "This profile is inactive."
 msgstr "Ky profil joaktiv."
 
-#: kuma/users/templates/account/email.html:3 kuma/users/templates/account/email.html:7 kuma/users/templates/users/user_detail.html:63
+#: kuma/users/templates/account/email.html:3
+#: kuma/users/templates/account/email.html:7
+#: kuma/users/templates/users/user_detail.html:63
 msgid "Email addresses"
 msgstr "Adresa email"
 
@@ -3241,8 +3917,12 @@ msgid "Remove"
 msgstr "Hiqe"
 
 #: kuma/users/templates/account/email.html:45
-msgid "<strong>Warning:</strong>\"You have not added any email addresses to this profile. Without one you cannot receive notifications."
-msgstr "<strong>Kujdes:</strong>\"S’keni shtuar ndonjë adresë email te ky profil. Pa një të tillë, s’mund të merrni njoftime."
+msgid ""
+"<strong>Warning:</strong>\"You have not added any email addresses to this "
+"profile. Without one you cannot receive notifications."
+msgstr ""
+"<strong>Kujdes:</strong>\"S’keni shtuar ndonjë adresë email te ky profil. Pa"
+" një të tillë, s’mund të merrni njoftime."
 
 #: kuma/users/templates/account/email.html:49
 msgid "Add email address"
@@ -3252,7 +3932,8 @@ msgstr "Shtoni adresë email"
 msgid "Add Email"
 msgstr "Shtoni Email"
 
-#: kuma/users/templates/account/email.html:60 kuma/users/templates/socialaccount/connections.html:70
+#: kuma/users/templates/account/email.html:60
+#: kuma/users/templates/socialaccount/connections.html:70
 msgid "Edit profile"
 msgstr "Përpunoni profil"
 
@@ -3260,15 +3941,21 @@ msgstr "Përpunoni profil"
 msgid "Do you really want to remove the selected email address?"
 msgstr "Doni vërtet ta hiqni adresën email të përzgjedhur?"
 
-#: kuma/users/templates/account/email_confirm.html:3 kuma/users/templates/account/email_confirm.html:9 kuma/users/templates/account/email_confirmed.html:3
+#: kuma/users/templates/account/email_confirm.html:3
+#: kuma/users/templates/account/email_confirm.html:9
+#: kuma/users/templates/account/email_confirmed.html:3
 #: kuma/users/templates/account/email_confirmed.html:8
 msgid "Confirm Email Address"
 msgstr "Ripohoni Adresën Email"
 
 #: kuma/users/templates/account/email_confirm.html:13
 #, python-format
-msgid "Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an email address for user %(user_display)s."
-msgstr "Ju lutemi, ripohoni se <a href=\"mailto:%(email)s\">%(email)s</a> është adresë email për përdoruesin %(user_display)s."
+msgid ""
+"Please confirm that <a href=\"mailto:%(email)s\">%(email)s</a> is an email "
+"address for user %(user_display)s."
+msgstr ""
+"Ju lutemi, ripohoni se <a href=\"mailto:%(email)s\">%(email)s</a> është "
+"adresë email për përdoruesin %(user_display)s."
 
 #: kuma/users/templates/account/email_confirm.html:17
 msgid "Confirm"
@@ -3276,13 +3963,21 @@ msgstr "Ripohojeni"
 
 #: kuma/users/templates/account/email_confirm.html:22
 #, python-format
-msgid "This email confirmation link expired or is invalid. Please <a href=\"%(email_url)s\">issue a new email confirmation request</a>."
-msgstr "Kjo lidhje ripohimi email-i ka skaduar ose s’është e vlefshme. Ju lutemi, <a href=\"%(email_url)s\">bëni një kërkesë të re email-i ripohimi</a>."
+msgid ""
+"This email confirmation link expired or is invalid. Please <a "
+"href=\"%(email_url)s\">issue a new email confirmation request</a>."
+msgstr ""
+"Kjo lidhje ripohimi email-i ka skaduar ose s’është e vlefshme. Ju lutemi, <a"
+" href=\"%(email_url)s\">bëni një kërkesë të re email-i ripohimi</a>."
 
 #: kuma/users/templates/account/email_confirmed.html:10
 #, python-format
-msgid "You have confirmed that <a href=\"mailto:%(email)s\">%(email)s</a> is an email address for user %(user_display)s."
-msgstr "Keni ripohuar se <a href=\"mailto:%(email)s\">%(email)s</a> është adresë email për përdoruesin %(user_display)s."
+msgid ""
+"You have confirmed that <a href=\"mailto:%(email)s\">%(email)s</a> is an "
+"email address for user %(user_display)s."
+msgstr ""
+"Keni ripohuar se <a href=\"mailto:%(email)s\">%(email)s</a> është adresë "
+"email për përdoruesin %(user_display)s."
 
 #: kuma/users/templates/account/login.html:3
 msgid "Sign In"
@@ -3293,12 +3988,19 @@ msgid "Please sign in"
 msgstr "Ju lutemi, futuni"
 
 #: kuma/users/templates/account/login.html:13
-msgid "In order to contribute, you need to sign in to MDN. You can sign in using any of the services below. A MDN profile will be created for you if you don't already have one."
+msgid ""
+"In order to contribute, you need to sign in to MDN. You can sign in using "
+"any of the services below. A MDN profile will be created for you if you "
+"don't already have one."
 msgstr ""
-"Që të mund të kontribuoni, lypset të bëni hyrjen te MDN-ja. Hyrjen mund ta bëni duke përdorur cilindo nga shërbimet më poshtë. Nëse s’keni ende një të tillë, do të krijohet për ju një profil te MDN-"
-"ja."
+"Që të mund të kontribuoni, lypset të bëni hyrjen te MDN-ja. Hyrjen mund ta "
+"bëni duke përdorur cilindo nga shërbimet më poshtë. Nëse s’keni ende një të "
+"tillë, do të krijohet për ju një profil te MDN-ja."
 
-#: kuma/users/templates/account/logout.html:3 kuma/users/templates/account/logout.html:8 kuma/users/templates/account/logout.html:17 templates/includes/common_macros.html:40
+#: kuma/users/templates/account/logout.html:3
+#: kuma/users/templates/account/logout.html:8
+#: kuma/users/templates/account/logout.html:17
+#: templates/includes/common_macros.html:40
 msgid "Sign Out"
 msgstr "Dilni"
 
@@ -3306,20 +4008,30 @@ msgstr "Dilni"
 msgid "Are you sure you want to sign out?"
 msgstr "Jeni të sigurt se doni të dilni?"
 
-#: kuma/users/templates/account/password_change.html:3 kuma/users/templates/account/password_change.html:8 kuma/users/templates/account/password_change.html:13
-#: kuma/users/templates/account/password_reset_from_key.html:3 kuma/users/templates/account/password_reset_from_key.html:12 kuma/users/templates/account/password_reset_from_key_done.html:3
+#: kuma/users/templates/account/password_change.html:3
+#: kuma/users/templates/account/password_change.html:8
+#: kuma/users/templates/account/password_change.html:13
+#: kuma/users/templates/account/password_reset_from_key.html:3
+#: kuma/users/templates/account/password_reset_from_key.html:12
+#: kuma/users/templates/account/password_reset_from_key_done.html:3
 #: kuma/users/templates/account/password_reset_from_key_done.html:7
 msgid "Change Password"
 msgstr "Ndryshoni Fjalëkalimin"
 
-#: kuma/users/templates/account/password_reset.html:3 kuma/users/templates/account/password_reset.html:8 kuma/users/templates/account/password_reset_done.html:3
+#: kuma/users/templates/account/password_reset.html:3
+#: kuma/users/templates/account/password_reset.html:8
+#: kuma/users/templates/account/password_reset_done.html:3
 #: kuma/users/templates/account/password_reset_done.html:8
 msgid "Password Reset"
 msgstr "Ricaktim Fjalëkalimi"
 
 #: kuma/users/templates/account/password_reset.html:13
-msgid "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it."
-msgstr "Harruat fjalëkalimin tuaj? Jepni më poshtë adresën tuaj email, dhe do t'ju dërgojmë një email që ju lejon ta ricaktoni."
+msgid ""
+"Forgotten your password? Enter your email address below, and we'll send you "
+"an email allowing you to reset it."
+msgstr ""
+"Harruat fjalëkalimin tuaj? Jepni më poshtë adresën tuaj email, dhe do t'ju "
+"dërgojmë një email që ju lejon ta ricaktoni."
 
 #: kuma/users/templates/account/password_reset.html:18
 msgid "Reset My Password"
@@ -3327,11 +4039,17 @@ msgstr "Ricakto Fjalëkalimin Tim"
 
 #: kuma/users/templates/account/password_reset.html:21
 msgid "Please contact us if you have any trouble resetting your password."
-msgstr "Ju lutemi, lidhuni me ne nëse keni ndonjë problem me ricaktimin e fjalëkalimit tuaj."
+msgstr ""
+"Ju lutemi, lidhuni me ne nëse keni ndonjë problem me ricaktimin e "
+"fjalëkalimit tuaj."
 
 #: kuma/users/templates/account/password_reset_done.html:14
-msgid "We have sent you an email. Please contact us if you do not receive it within a few minutes."
-msgstr "Ju keni dërguar një email. Ju lutemi, lidhuni me ne, nëse s’e merrni brenda pak minutash."
+msgid ""
+"We have sent you an email. Please contact us if you do not receive it within"
+" a few minutes."
+msgstr ""
+"Ju keni dërguar një email. Ju lutemi, lidhuni me ne, nëse s’e merrni brenda "
+"pak minutash."
 
 #: kuma/users/templates/account/password_reset_from_key.html:10
 msgid "Bad Token"
@@ -3339,18 +4057,27 @@ msgstr "Token i gabuar"
 
 #: kuma/users/templates/account/password_reset_from_key.html:17
 #, python-format
-msgid "The password reset link was invalid, possibly because it has already been used.  Please request a <a href=\"%(passwd_reset_url)s\">new password reset</a>."
-msgstr "Lidhja e ricaktimit të fjalëkalimit qe e pavlefshme, mundet ngaqë është përdorur tashmë.  Ju lutemi, kërkoni <a href=\"%(passwd_reset_url)s\">një ricaktim të ri fjalëkalimi</a>."
+msgid ""
+"The password reset link was invalid, possibly because it has already been "
+"used.  Please request a <a href=\"%(passwd_reset_url)s\">new password "
+"reset</a>."
+msgstr ""
+"Lidhja e ricaktimit të fjalëkalimit qe e pavlefshme, mundet ngaqë është "
+"përdorur tashmë.  Ju lutemi, kërkoni <a href=\"%(passwd_reset_url)s\">një "
+"ricaktim të ri fjalëkalimi</a>."
 
 #: kuma/users/templates/account/password_reset_from_key.html:23
 msgid "Change password"
 msgstr "Ndryshoni fjalëkalimin"
 
-#: kuma/users/templates/account/password_reset_from_key.html:26 kuma/users/templates/account/password_reset_from_key_done.html:8
+#: kuma/users/templates/account/password_reset_from_key.html:26
+#: kuma/users/templates/account/password_reset_from_key_done.html:8
 msgid "Your password is now changed."
 msgstr "Fjalëkalimi juaj tani u ndryshua."
 
-#: kuma/users/templates/account/password_set.html:3 kuma/users/templates/account/password_set.html:7 kuma/users/templates/account/password_set.html:12
+#: kuma/users/templates/account/password_set.html:3
+#: kuma/users/templates/account/password_set.html:7
+#: kuma/users/templates/account/password_set.html:12
 msgid "Set Password"
 msgstr "Caktoni Një Fjalëkalim"
 
@@ -3358,16 +4085,21 @@ msgstr "Caktoni Një Fjalëkalim"
 msgid "Signup"
 msgstr "Regjistrim"
 
-#: kuma/users/templates/account/signup.html:8 kuma/users/templates/account/signup.html:18
+#: kuma/users/templates/account/signup.html:8
+#: kuma/users/templates/account/signup.html:18
 msgid "Sign Up"
 msgstr "Regjistrohuni"
 
 #: kuma/users/templates/account/signup.html:10
 #, python-format
-msgid "Already have an profile? Then please <a href=\"%(login_url)s\">sign in</a>."
-msgstr "Keni tashmë një profil? Atëherë, ju lutemi, <a href=\"%(login_url)s\">hyni</a>."
+msgid ""
+"Already have an profile? Then please <a href=\"%(login_url)s\">sign in</a>."
+msgstr ""
+"Keni tashmë një profil? Atëherë, ju lutemi, <a "
+"href=\"%(login_url)s\">hyni</a>."
 
-#: kuma/users/templates/account/signup_closed.html:3 kuma/users/templates/account/signup_closed.html:7
+#: kuma/users/templates/account/signup_closed.html:3
+#: kuma/users/templates/account/signup_closed.html:7
 msgid "Profile Creation Disabled"
 msgstr "Krijimi i Profileve Është i Çaktivizuar"
 
@@ -3375,27 +4107,50 @@ msgstr "Krijimi i Profileve Është i Çaktivizuar"
 msgid "We are sorry, but profile creation is currently disabled."
 msgstr "Na ndjeni, por krijimi i profileve hëpërhë është i çaktivizuar."
 
-#: kuma/users/templates/account/verification_sent.html:3 kuma/users/templates/account/verification_sent.html:7 kuma/users/templates/account/verified_email_required.html:3
+#: kuma/users/templates/account/verification_sent.html:3
+#: kuma/users/templates/account/verification_sent.html:7
+#: kuma/users/templates/account/verified_email_required.html:3
 #: kuma/users/templates/account/verified_email_required.html:7
 msgid "Confirm Your Email Address"
 msgstr "Ripohoni Adresën Tuaj Email"
 
 #: kuma/users/templates/account/verification_sent.html:9
-msgid "We have sent an email to you for confirmation. Follow the link provided to finalize the signup process. Please contact us if you do not receive it within a few minutes."
-msgstr "Ju kemi dërguar një email për ripohimin. Ndiqni lidhjen e dhënë që të finalizoni procesin e regjistrimit. Ju lutemi, lidhuni me ne, nëse s’e merrni brenda pak minutash."
+msgid ""
+"We have sent an email to you for confirmation. Follow the link provided to "
+"finalize the signup process. Please contact us if you do not receive it "
+"within a few minutes."
+msgstr ""
+"Ju kemi dërguar një email për ripohimin. Ndiqni lidhjen e dhënë që të "
+"finalizoni procesin e regjistrimit. Ju lutemi, lidhuni me ne, nëse s’e "
+"merrni brenda pak minutash."
 
 #: kuma/users/templates/account/verified_email_required.html:9
-msgid "This part of the site requires us to confirm that you are who you claim to be. For this purpose, we require that you confirm ownership of your email address."
-msgstr "Kjo pjesë e sajtit kërkon doemos të ripohoni se jeni ai që pretendoni se jeni. Për këtë arsye, kërkojmë të ripohoni pronësinë mbi adresën tuaj email."
+msgid ""
+"This part of the site requires us to confirm that you are who you claim to "
+"be. For this purpose, we require that you confirm ownership of your email "
+"address."
+msgstr ""
+"Kjo pjesë e sajtit kërkon doemos të ripohoni se jeni ai që pretendoni se "
+"jeni. Për këtë arsye, kërkojmë të ripohoni pronësinë mbi adresën tuaj email."
 
 #: kuma/users/templates/account/verified_email_required.html:13
-msgid "We have sent an email to you for confirmation. Please click on the link inside this email. Please contact us if you do not receive it within a few minutes."
-msgstr "Ju kemi dërguar një email për ripohimin. Ju lutemi, klikoni mbi lidhjen brenda atij email-i. Ju lutemi, lidhuni me ne, nëse s’e merrni brenda pak minutash."
+msgid ""
+"We have sent an email to you for confirmation. Please click on the link "
+"inside this email. Please contact us if you do not receive it within a few "
+"minutes."
+msgstr ""
+"Ju kemi dërguar një email për ripohimin. Ju lutemi, klikoni mbi lidhjen "
+"brenda atij email-i. Ju lutemi, lidhuni me ne, nëse s’e merrni brenda pak "
+"minutash."
 
 #: kuma/users/templates/account/verified_email_required.html:17
 #, python-format
-msgid "<strong>Note:</strong> you can still <a href=\"%(email_url)s\">change your email address</a>."
-msgstr "<strong>Shënim:</strong> mundeni edhe të <a href=\"%(email_url)s\">ndryshoni adresën tuaj email</a>."
+msgid ""
+"<strong>Note:</strong> you can still <a href=\"%(email_url)s\">change your "
+"email address</a>."
+msgstr ""
+"<strong>Shënim:</strong> mundeni edhe të <a href=\"%(email_url)s\">ndryshoni"
+" adresën tuaj email</a>."
 
 #: kuma/users/templates/account/snippets/already_logged_in.html:1
 msgid "Note"
@@ -3406,11 +4161,13 @@ msgstr "Shënim"
 msgid "you are already logged in as %(user_display)s."
 msgstr "jeni i futur tashmë si %(user_display)s."
 
-#: kuma/users/templates/openid/login.html:3 kuma/users/templates/openid/login.html:6
+#: kuma/users/templates/openid/login.html:3
+#: kuma/users/templates/openid/login.html:6
 msgid "OpenID Sign In"
 msgstr "Hyrje me OpenID"
 
-#: kuma/users/templates/socialaccount/authentication_error.html:3 kuma/users/templates/socialaccount/authentication_error.html:6
+#: kuma/users/templates/socialaccount/authentication_error.html:3
+#: kuma/users/templates/socialaccount/authentication_error.html:6
 msgid "Account Sign In Failure"
 msgstr "Dështim Hyrjeje Në Llogari"
 
@@ -3422,7 +4179,8 @@ msgstr "Ndodhi një gabim teksa përpiqeshit të hynit me llogarinë tuaj."
 msgid "Account Connections"
 msgstr "Lidhje Llogarie"
 
-#: kuma/users/templates/socialaccount/connections.html:6 kuma/users/templates/users/user_detail.html:61
+#: kuma/users/templates/socialaccount/connections.html:6
+#: kuma/users/templates/users/user_detail.html:61
 msgid "Account connections"
 msgstr "Lidhje llogarie"
 
@@ -3442,101 +4200,162 @@ msgstr "S’keni llogari të lidhura."
 msgid "Connect a new account"
 msgstr "Lidhni llogari të re"
 
-#: kuma/users/templates/socialaccount/login_cancelled.html:3 kuma/users/templates/socialaccount/login_cancelled.html:7
+#: kuma/users/templates/socialaccount/login_cancelled.html:3
+#: kuma/users/templates/socialaccount/login_cancelled.html:7
 msgid "Login Cancelled"
 msgstr "Hyrja u Anulua"
 
 #: kuma/users/templates/socialaccount/login_cancelled.html:9
 #, python-format
-msgid "You decided to cancel logging in to our site using one of your existing accounts. If this was a mistake, please proceed to <a href=\"%(login_url)s\">sign in</a>."
-msgstr "Vendosët ta anuloni hyrjen te sajti ynë përmes njërës prej llogarive tuaja ekzistuese. Nëse ky qe një gabim, ju lutemi, vazhdoni me <a href=\"%(login_url)s\">hyrjen</a>."
+msgid ""
+"You decided to cancel logging in to our site using one of your existing "
+"accounts. If this was a mistake, please proceed to <a "
+"href=\"%(login_url)s\">sign in</a>."
+msgstr ""
+"Vendosët ta anuloni hyrjen te sajti ynë përmes njërës prej llogarive tuaja "
+"ekzistuese. Nëse ky qe një gabim, ju lutemi, vazhdoni me <a "
+"href=\"%(login_url)s\">hyrjen</a>."
 
-#: kuma/users/templates/socialaccount/signup.html:4 kuma/users/templates/socialaccount/signup.html:26
+#: kuma/users/templates/socialaccount/signup.html:4
+#: kuma/users/templates/socialaccount/signup.html:26
 msgid "Create your MDN profile to continue"
 msgstr "Krijoni profilin tuaj MDN që të vazhdohet"
 
 #: kuma/users/templates/socialaccount/signup.html:30
 #, python-format
-msgid "A profile already exists with this email address. To connect Persona to your MDN profile, <a href=\"%(connections_url)s\">you need to sign in and visit your social account connections.</a>"
+msgid ""
+"A profile already exists with this email address. To connect Persona to your"
+" MDN profile, <a href=\"%(connections_url)s\">you need to sign in and visit "
+"your social account connections.</a>"
 msgstr ""
-"Ka tashmë një profil me atë adresë email. Për ta lidhur Persona-n me profilin tuaj MDN, <a href=\"%(connections_url)s\">lypset të bëni hyrjen dhe të vizitoni lidhjet për llogari mediash shoqërore.</"
-"a>"
+"Ka tashmë një profil me atë adresë email. Për ta lidhur Persona-n me "
+"profilin tuaj MDN, <a href=\"%(connections_url)s\">lypset të bëni hyrjen dhe"
+" të vizitoni lidhjet për llogari mediash shoqërore.</a>"
 
 #: kuma/users/templates/socialaccount/signup.html:43
 #, python-format
 msgid ""
-"A profile already exists with an email address below. Do you already have an MDN profile? <a href=\"%(persona_login_url)s\" class=\"launch-persona-login\" data-next=\"%(persona_next_url)s\">Yes, "
-"connect with my MDN profile</a>"
+"A profile already exists with an email address below. Do you already have an"
+" MDN profile? <a href=\"%(persona_login_url)s\" class=\"launch-persona-"
+"login\" data-next=\"%(persona_next_url)s\">Yes, connect with my MDN "
+"profile</a>"
 msgid_plural ""
-"A profile already exists with one of these email addresses below. Do you already have an MDN profile? <a href=\"%(persona_login_url)s\" class=\"launch-persona-login\" data-next="
-"\"%(persona_next_url)s\">Yes, connect with my MDN profile</a>"
+"A profile already exists with one of these email addresses below. Do you "
+"already have an MDN profile? <a href=\"%(persona_login_url)s\" class"
+"=\"launch-persona-login\" data-next=\"%(persona_next_url)s\">Yes, connect "
+"with my MDN profile</a>"
 msgstr[0] ""
-"Ka tashmë një profil me adresën email më poshtë. Keni tashmë një profil MDN-je? <a href=\"%(persona_login_url)s\" class=\"launch-persona-login\" data-next=\"%(persona_next_url)s\">Po, lidhu me "
-"profilin tim te MDN-ja</a>"
+"Ka tashmë një profil me adresën email më poshtë. Keni tashmë një profil MDN-"
+"je? <a href=\"%(persona_login_url)s\" class=\"launch-persona-login\" data-"
+"next=\"%(persona_next_url)s\">Po, lidhu me profilin tim te MDN-ja</a>"
 msgstr[1] ""
-"Ka tashmë një profil me një nga adresat email më poshtë. Keni tashmë një profil MDN-je? <a href=\"%(persona_login_url)s\" class=\"launch-persona-login\" data-next=\"%(persona_next_url)s\">Po, lidhu "
-"me profilin tim te MDN-ja</a>"
+"Ka tashmë një profil me një nga adresat email më poshtë. Keni tashmë një "
+"profil MDN-je? <a href=\"%(persona_login_url)s\" class=\"launch-persona-"
+"login\" data-next=\"%(persona_next_url)s\">Po, lidhu me profilin tim te MDN-"
+"ja</a>"
 
 #: kuma/users/templates/socialaccount/signup.html:55
 #, python-format
-msgid "Thanks for signing in to MDN with %(provider_name)s. You have one more step to join MDN: <strong>create your MDN profile</strong>."
-msgstr "Ju faleminderit që hytë te MDN-ja përmes %(provider_name)s. Keni ende një hap që të merrni pjesë te MDN-ja: <strong>krijoni profilin tuaj te MDN-ja</strong>."
+msgid ""
+"Thanks for signing in to MDN with %(provider_name)s. You have one more step "
+"to join MDN: <strong>create your MDN profile</strong>."
+msgstr ""
+"Ju faleminderit që hytë te MDN-ja përmes %(provider_name)s. Keni ende një "
+"hap që të merrni pjesë te MDN-ja: <strong>krijoni profilin tuaj te MDN-"
+"ja</strong>."
 
 #: kuma/users/templates/socialaccount/signup.html:61
-msgid "You can access everything on the MDN website even without an MDN profile. However, by joining MDN, you'll be able to edit docs, submit demos, and have your own profile page."
+msgid ""
+"You can access everything on the MDN website even without an MDN profile. "
+"However, by joining MDN, you'll be able to edit docs, submit demos, and have"
+" your own profile page."
 msgstr ""
-"Mund të hapni gjithçka te sajti i MDN-së, edhe pa pasur profil te MDN-ja. Megjithatë, duke u bërë pjesë e MDN-së, do të jeni në gjendje të përpunoni dokumentime, të parashtroni demo, dhe të keni "
-"faqen e profilit tuaj."
+"Mund të hapni gjithçka te sajti i MDN-së, edhe pa pasur profil te MDN-ja. "
+"Megjithatë, duke u bërë pjesë e MDN-së, do të jeni në gjendje të përpunoni "
+"dokumentime, të parashtroni demo, dhe të keni faqen e profilit tuaj."
 
 #: kuma/users/templates/socialaccount/signup.html:68
-msgid "To set up your MDN profile, please <strong>choose a username</strong>. Your username will be displayed on MDN to identify any contributions (edits, demos, etc.) that you make."
+msgid ""
+"To set up your MDN profile, please <strong>choose a username</strong>. Your "
+"username will be displayed on MDN to identify any contributions (edits, "
+"demos, etc.) that you make."
 msgstr ""
-"Që të rregulloni profilin tuaj te MDN-ja, ju lutemi, <strong>zgjidhni një emër përdoruesi</strong>. Emri juaj i përdoruesit do të shfaqet te MDN-ja për t’ju atribuuar çfarëdo kontributi (përpunime, "
-"demo, etj.) që bëni."
+"Që të rregulloni profilin tuaj te MDN-ja, ju lutemi, <strong>zgjidhni një "
+"emër përdoruesi</strong>. Emri juaj i përdoruesit do të shfaqet te MDN-ja "
+"për t’ju atribuuar çfarëdo kontributi (përpunime, demo, etj.) që bëni."
 
 #: kuma/users/templates/socialaccount/signup.html:74
 msgid ""
-"To set up your MDN profile, please <strong>choose a username and email address</strong>. Your username will be displayed on MDN to identify any contributions (edits, demos, etc.) that you make."
+"To set up your MDN profile, please <strong>choose a username and email "
+"address</strong>. Your username will be displayed on MDN to identify any "
+"contributions (edits, demos, etc.) that you make."
 msgstr ""
-"Që të rregulloni profilin tuaj te MDN-ja, ju lutemi, <strong>zgjidhni një emër përdoruesi dhe një adresë email</strong>. Emri juaj i përdoruesit do të shfaqet te MDN-ja për t’ju atribuuar çfarëdo "
-"kontributi (përpunime, demo, etj.) që bëni."
+"Që të rregulloni profilin tuaj te MDN-ja, ju lutemi, <strong>zgjidhni një "
+"emër përdoruesi dhe një adresë email</strong>. Emri juaj i përdoruesit do të"
+" shfaqet te MDN-ja për t’ju atribuuar çfarëdo kontributi (përpunime, demo, "
+"etj.) që bëni."
 
 #: kuma/users/templates/socialaccount/signup.html:82
 #, python-format
-msgid "If you're <strong>having trouble</strong> signing in or creating an MDN profile, <strong><a href=\"%(bug_href)s\" rel=\"external\">let us know</a></strong>."
-msgstr "Nëse <strong>keni probleme</strong> me hyrjen ose me krijimin e një profili MDN, <strong><a href=\"%(bug_href)s\" rel=\"external\">na e bëni të ditur</a></strong>."
+msgid ""
+"If you're <strong>having trouble</strong> signing in or creating an MDN "
+"profile, <strong><a href=\"%(bug_href)s\" rel=\"external\">let us "
+"know</a></strong>."
+msgstr ""
+"Nëse <strong>keni probleme</strong> me hyrjen ose me krijimin e një profili "
+"MDN, <strong><a href=\"%(bug_href)s\" rel=\"external\">na e bëni të "
+"ditur</a></strong>."
 
 #: kuma/users/templates/socialaccount/signup.html:107
 #, python-format
-msgid "Your GitHub username %(username)s is already taken. Please choose another."
-msgstr "Emri juaj si përdorues në GitHub, %(username)s, është i zënë tashmë. Ju lutemi, zgjidhni një tjetër."
+msgid ""
+"Your GitHub username %(username)s is already taken. Please choose another."
+msgstr ""
+"Emri juaj si përdorues në GitHub, %(username)s, është i zënë tashmë. Ju "
+"lutemi, zgjidhni një tjetër."
 
 #: kuma/users/templates/socialaccount/signup.html:111
-msgid "Please enter the name you'd like to display to other users to identify your contributions."
-msgstr "Ju lutemi, jepni emrin që do të donit t’u shfaqet përdoruesve të tjerë për identifikim të kontributit tuaj."
+msgid ""
+"Please enter the name you'd like to display to other users to identify your "
+"contributions."
+msgstr ""
+"Ju lutemi, jepni emrin që do të donit t’u shfaqet përdoruesve të tjerë për "
+"identifikim të kontributit tuaj."
 
 #: kuma/users/templates/socialaccount/signup.html:125
 #, python-format
 msgid ""
-"A profile already exists with the selected email address. <a href=\"%(persona_login_url)s\" class=\"launch-persona-login\" data-next=\"%(persona_next_url)s\">Connect your %(provider_name)s account "
-"to it.</a>"
+"A profile already exists with the selected email address. <a "
+"href=\"%(persona_login_url)s\" class=\"launch-persona-login\" data-"
+"next=\"%(persona_next_url)s\">Connect your %(provider_name)s account to "
+"it.</a>"
 msgstr ""
-"Ka tashmë një profil me adresën email të përzgjedhur. <a href=\"%(persona_login_url)s\" class=\"launch-persona-login\" data-next=\"%(persona_next_url)s\">Lidheni llogarinë tuaj %(provider_name)s me "
+"Ka tashmë një profil me adresën email të përzgjedhur. <a "
+"href=\"%(persona_login_url)s\" class=\"launch-persona-login\" data-"
+"next=\"%(persona_next_url)s\">Lidheni llogarinë tuaj %(provider_name)s me "
 "të.</a>"
 
 #: kuma/users/templates/socialaccount/signup.html:155
 #, python-format
 msgid ""
-"What email address should we use to send you MDN-related messages and notifications? This address will <strong>not</strong> be displayed on MDN and will be used according to our <a href="
-"\"%(privacy_url)s\">privacy policy</a>."
+"What email address should we use to send you MDN-related messages and "
+"notifications? This address will <strong>not</strong> be displayed on MDN "
+"and will be used according to our <a href=\"%(privacy_url)s\">privacy "
+"policy</a>."
 msgstr ""
-"Cilën adresë email do të duhej të përdornim për t’ju dërguar mesazhe dhe njoftime MDN? Kjo adresë <strong>nuk</strong> do të shfaqet te MDN-ja dhe do të përdoret në pajtim me <a href="
-"\"\"%(privacy_url)s\">rregullat tona mbi privatësinë</a>."
+"Cilën adresë email do të duhej të përdornim për t’ju dërguar mesazhe dhe "
+"njoftime MDN? Kjo adresë <strong>nuk</strong> do të shfaqet te MDN-ja dhe do"
+" të përdoret në pajtim me <a href=\"\"%(privacy_url)s\">rregullat tona mbi "
+"privatësinë</a>."
 
 #: kuma/users/templates/socialaccount/signup.html:170
 #, python-format
-msgid "to Mozilla's <a href=\"%(terms_url)s\">Terms</a> and <a href=\"%(privacy_url)s\">Privacy Notice</a>."
-msgstr "te <a href=\"%(terms_url)s\">Kushtet</a> dhe <a href=\"%(privacy_url)s\">Shënimi i Privatësisë</a> së Mozilla-s."
+msgid ""
+"to Mozilla's <a href=\"%(terms_url)s\">Terms</a> and <a "
+"href=\"%(privacy_url)s\">Privacy Notice</a>."
+msgstr ""
+"te <a href=\"%(terms_url)s\">Kushtet</a> dhe <a "
+"href=\"%(privacy_url)s\">Shënimi i Privatësisë</a> së Mozilla-s."
 
 #: kuma/users/templates/socialaccount/signup.html:179
 msgid "Create my MDN profile"
@@ -3566,14 +4385,19 @@ msgstr "Lidhuni përmes GitHub-it"
 msgid "Sign in with GitHub"
 msgstr "Hyni me GitHub"
 
-#: kuma/users/templates/users/apps_newsletter.html:7 templates/includes/newsletter.html:4
+#: kuma/users/templates/users/apps_newsletter.html:7
+#: templates/includes/newsletter.html:4
 msgid "Firefox Apps & Hacks Newsletter"
 msgstr "Buletini Firefox Apps & Hacks"
 
 #: kuma/users/templates/users/apps_newsletter.html:14
 #, python-format
-msgid "<a href=\"%(profile_edit_url)s\">Edit your profile</a> to join the newsletter."
-msgstr "<a href=\"%(profile_edit_url)s\">Përpunoni profilin tuaj</a> që të pajtoheni te buletini."
+msgid ""
+"<a href=\"%(profile_edit_url)s\">Edit your profile</a> to join the "
+"newsletter."
+msgstr ""
+"<a href=\"%(profile_edit_url)s\">Përpunoni profilin tuaj</a> që të pajtoheni"
+" te buletini."
 
 #: kuma/users/templates/users/user_banned.html:2
 msgid "You've Been Banned"
@@ -3584,14 +4408,21 @@ msgid "You have been banned for the following reasons:"
 msgstr "Jeni përzënë për arsyet vijuese:"
 
 #: kuma/users/templates/users/user_banned.html:30
-msgid "<p><a href=\"mailto:mdn-admins@mozilla.org?subject=Ban Appeal\">Click here</a> to appeal this ban.</p>"
-msgstr "<p><a href=\"mailto:mdn-admins@mozilla.org?subject=Ban Appeal\">Klikoni këtu</a> që ta apeloni këtë dëbim.</p>"
+msgid ""
+"<p><a href=\"mailto:mdn-admins@mozilla.org?subject=Ban Appeal\">Click "
+"here</a> to appeal this ban.</p>"
+msgstr ""
+"<p><a href=\"mailto:mdn-admins@mozilla.org?subject=Ban Appeal\">Klikoni "
+"këtu</a> që ta apeloni këtë dëbim.</p>"
 
-#: kuma/users/templates/users/user_detail.html:53 kuma/wiki/content.py:718 kuma/wiki/templates/wiki/includes/buttons.html:40
+#: kuma/users/templates/users/user_detail.html:53 kuma/wiki/content.py:718
+#: kuma/wiki/templates/wiki/includes/buttons.html:40
 msgid "Edit"
 msgstr "Përpunoni"
 
-#: kuma/users/templates/users/user_detail.html:55 kuma/wiki/templates/wiki/includes/buttons.html:53 kuma/wiki/templates/wiki/includes/buttons.html:57
+#: kuma/users/templates/users/user_detail.html:55
+#: kuma/wiki/templates/wiki/includes/buttons.html:53
+#: kuma/wiki/templates/wiki/includes/buttons.html:57
 msgid "Advanced"
 msgstr "Të mëtejshme"
 
@@ -3623,8 +4454,12 @@ msgstr "Pa Demo"
 
 #: kuma/users/templates/users/user_detail.html:169
 #, python-format
-msgid "You haven't submitted any web technology demos. Build something awesome and <a href=\"%(submit_url)s\">submit a demo</a>!"
-msgstr "S’keni parashtruar ndonjë demo teknologjish web. Krijoni diçka mahnitëse dhe <a href=\"%(submit_url)s\">parashtroni një demo</a>!"
+msgid ""
+"You haven't submitted any web technology demos. Build something awesome and "
+"<a href=\"%(submit_url)s\">submit a demo</a>!"
+msgstr ""
+"S’keni parashtruar ndonjë demo teknologjish web. Krijoni diçka mahnitëse dhe"
+" <a href=\"%(submit_url)s\">parashtroni një demo</a>!"
 
 #: kuma/users/templates/users/user_detail.html:175
 msgid "Recent Docs Activity"
@@ -3638,11 +4473,14 @@ msgstr "Shihni krejt veprimtarinë"
 msgid "Page"
 msgstr "Faqe"
 
-#: kuma/users/templates/users/user_detail.html:182 kuma/wiki/templates/wiki/confirm_revision_revert.html:32 kuma/wiki/templates/wiki/revision.html:42
+#: kuma/users/templates/users/user_detail.html:182
+#: kuma/wiki/templates/wiki/confirm_revision_revert.html:32
+#: kuma/wiki/templates/wiki/revision.html:42
 msgid "Comment"
 msgstr "Koment"
 
-#: kuma/users/templates/users/user_detail.html:190 kuma/wiki/templates/wiki/document.html:399
+#: kuma/users/templates/users/user_detail.html:190
+#: kuma/wiki/templates/wiki/document.html:399
 msgid "Edit page"
 msgstr "Përpunoni faqen"
 
@@ -3650,14 +4488,19 @@ msgstr "Përpunoni faqen"
 msgid "View complete diff"
 msgstr "Shihni plotësisht dallimet"
 
-#: kuma/users/templates/users/user_detail.html:192 kuma/wiki/templates/wiki/document.html:400
+#: kuma/users/templates/users/user_detail.html:192
+#: kuma/wiki/templates/wiki/document.html:400
 msgid "View page history"
 msgstr "Shihni historik faqeje"
 
 #: kuma/users/templates/users/user_detail.html:204
 #, python-format
-msgid "<p class=\"none\">You haven't contributed to any MDN docs. <a href=\"%(docs_url)s\">Pitch in!</a></p>"
-msgstr "<p class=\"none\">S’keni kontribuar te ndonjë dokument MDN. <a href=\"%(docs_url)s\">VIni dhe ju një dorë!</a></p>"
+msgid ""
+"<p class=\"none\">You haven't contributed to any MDN docs. <a "
+"href=\"%(docs_url)s\">Pitch in!</a></p>"
+msgstr ""
+"<p class=\"none\">S’keni kontribuar te ndonjë dokument MDN. <a "
+"href=\"%(docs_url)s\">VIni dhe ju një dorë!</a></p>"
 
 #: kuma/users/templates/users/user_detail.html:208
 msgid "This user has no activity."
@@ -3680,10 +4523,14 @@ msgid "You're editing a different profile than your own. Please take care!"
 msgstr "Po përpunoni një profil tjetër nga i juaji. Ju lutemi, bëni kujdes!"
 
 #: kuma/users/templates/users/user_edit.html:63
-msgid "We'd love to have your feedback on site changes! Beta testers get access to new features first and we send the occasional email asking for help testing specific things."
+msgid ""
+"We'd love to have your feedback on site changes! Beta testers get access to "
+"new features first and we send the occasional email asking for help testing "
+"specific things."
 msgstr ""
-"Do të donim të dinim përshtypjet tuaja rreth ndryshimeve të sajtit! Testuesit beta mund të përdorin të parët veçoritë e reja, dhe ne dërgojmë me raste edhe kërkesa për ndihmë në testimin e gjërave "
-"të veçanta."
+"Do të donim të dinim përshtypjet tuaja rreth ndryshimeve të sajtit! "
+"Testuesit beta mund të përdorin të parët veçoritë e reja, dhe ne dërgojmë me"
+" raste edhe kërkesa për ndihmë në testimin e gjërave të veçanta."
 
 #: kuma/users/templates/users/user_edit.html:66
 msgid "Primary Email"
@@ -3706,22 +4553,31 @@ msgid "Interests (tags)"
 msgstr "Interesa (etiketa)"
 
 #: kuma/users/templates/users/user_edit.html:86
-msgid "Separate tags with commas or spaces. Join multi-word tags with double quotes, like \"web standards\"."
-msgstr "Etiketat ndajini me presje ose hapësira. Etiketat e përbëra vendosini brenda thonjëzash, si kjo \"standarde web\"."
+msgid ""
+"Separate tags with commas or spaces. Join multi-word tags with double "
+"quotes, like \"web standards\"."
+msgstr ""
+"Etiketat ndajini me presje ose hapësira. Etiketat e përbëra vendosini brenda"
+" thonjëzash, si kjo \"standarde web\"."
 
 #: kuma/users/templates/users/user_edit.html:92
 msgid "Areas of expertise"
 msgstr "Fusha ekspertize"
 
 #: kuma/users/templates/users/user_edit.html:93
-msgid "Add your interests first, then declare yourself an expert in selected topics."
-msgstr "Së pari shtoni interesat tuaja, mandej deklarohuni ekspert në fusha të caktuara."
+msgid ""
+"Add your interests first, then declare yourself an expert in selected "
+"topics."
+msgstr ""
+"Së pari shtoni interesat tuaja, mandej deklarohuni ekspert në fusha të "
+"caktuara."
 
 #: kuma/users/templates/users/user_edit.html:101
 msgid "My Profiles"
 msgstr "Profilet e Mia"
 
-#: kuma/users/templates/users/user_edit.html:106 kuma/users/templates/users/user_edit.html:124
+#: kuma/users/templates/users/user_edit.html:106
+#: kuma/users/templates/users/user_edit.html:124
 msgid "Change"
 msgstr "Ndryshoje"
 
@@ -3733,7 +4589,9 @@ msgstr "Për hyrjen përdorni llogarinë tuaj Persona."
 msgid "Use your GitHub account to sign in."
 msgstr "Përdorni për hyrje llogarinë tuaj GitHub."
 
-#: kuma/users/templates/users/user_edit.html:153 kuma/users/templates/users/user_edit.html:161 kuma/wiki/templates/wiki/includes/page_buttons.html:27
+#: kuma/users/templates/users/user_edit.html:153
+#: kuma/users/templates/users/user_edit.html:161
+#: kuma/wiki/templates/wiki/includes/page_buttons.html:27
 msgid "Save Changes"
 msgstr "Ruaji Ndryshimet"
 
@@ -3744,55 +4602,96 @@ msgstr "Njatjeta %(username)s!"
 
 #: kuma/users/templates/users/email/welcome/html.ltxt:11
 #, python-format
-msgid "Thanks for creating a profile on <a href=\"%(mdn_link)s\">Mozilla Developer Network (MDN)</a> - a community making great resources for developers like you."
-msgstr "Faleminderit për krijimin e profilit te <a href=\"%(mdn_link)s\">Rrjeti i Zhvilluesve Mozilla (MDN)</a> - një bashkësi që krijon burime të shkëlqyera për zhvillues si ju."
+msgid ""
+"Thanks for creating a profile on <a href=\"%(mdn_link)s\">Mozilla Developer "
+"Network (MDN)</a> - a community making great resources for developers like "
+"you."
+msgstr ""
+"Faleminderit për krijimin e profilit te <a href=\"%(mdn_link)s\">Rrjeti i "
+"Zhvilluesve Mozilla (MDN)</a> - një bashkësi që krijon burime të shkëlqyera "
+"për zhvillues si ju."
 
 #: kuma/users/templates/users/email/welcome/html.ltxt:16
 #, python-format
-msgid "You've completed the first step of <a href=\"%(started_link)s\">Getting Started on MDN</a> by creating a profile."
-msgstr "Duke krijuar një profil, plotësuat hapin e parë te <a href=\"%(started_link)s\">Si T’ia Fillohet Te MDN</a>."
+msgid ""
+"You've completed the first step of <a href=\"%(started_link)s\">Getting "
+"Started on MDN</a> by creating a profile."
+msgstr ""
+"Duke krijuar një profil, plotësuat hapin e parë te <a "
+"href=\"%(started_link)s\">Si T’ia Fillohet Te MDN</a>."
 
 #: kuma/users/templates/users/email/welcome/html.ltxt:21
 #, python-format
 msgid ""
-"Now, keep going by picking a task on MDN, and doing it! We have a bunch of intro tasks you can choose from, whether you <a href=\"%(words_link)s\">like words</a>, <a href=\"%(code_link)s\">like "
-"code</a>, <a href=\"%(both_link)s\">like both words and code</a>, or you want to <a href=\"%(translate_link)s\">translate MDN to your language</a>."
+"Now, keep going by picking a task on MDN, and doing it! We have a bunch of "
+"intro tasks you can choose from, whether you <a href=\"%(words_link)s\">like"
+" words</a>, <a href=\"%(code_link)s\">like code</a>, <a "
+"href=\"%(both_link)s\">like both words and code</a>, or you want to <a "
+"href=\"%(translate_link)s\">translate MDN to your language</a>."
 msgstr ""
-"Tani vazhdoni duke zgjedhur një punë te MDN-ja, dhe duke e përmbushur atë! Kemi një dorë punësh fillestare prej nga të cilat mund të zgjidhni, si kur ju <a href=\"%(words_link)s\">pëlqejnë fjalët</"
-"a>, <a href=\"%(code_link)s\">pëlqen kodi</a>, <a href=\"%(both_link)s\">pëlqejnë edhe fjalët, edhe kodi</a>, ose dëshironi të <a href=\"%(translate_link)s\">përktheni MDN-në në gjuhën tuaj</a>."
+"Tani vazhdoni duke zgjedhur një punë te MDN-ja, dhe duke e përmbushur atë! "
+"Kemi një dorë punësh fillestare prej nga të cilat mund të zgjidhni, si kur "
+"ju <a href=\"%(words_link)s\">pëlqejnë fjalët</a>, <a "
+"href=\"%(code_link)s\">pëlqen kodi</a>, <a href=\"%(both_link)s\">pëlqejnë "
+"edhe fjalët, edhe kodi</a>, ose dëshironi të <a "
+"href=\"%(translate_link)s\">përktheni MDN-në në gjuhën tuaj</a>."
 
 #: kuma/users/templates/users/email/welcome/html.ltxt:34
 msgid "Talk to us!"
 msgstr "Flisni me ne!"
 
 #. This is an email. Whitespace matters!
-#: kuma/users/templates/users/email/welcome/html.ltxt:35 kuma/users/templates/users/email/welcome/plain.ltxt:30
-msgid "Want to talk to someone about MDN? There are a few ways you can do that:"
-msgstr "Dëshironi të bisedoni me dikë rreth MDN-së? Ka disa mënyra për ta bërë këtë:"
+#: kuma/users/templates/users/email/welcome/html.ltxt:35
+#: kuma/users/templates/users/email/welcome/plain.ltxt:30
+msgid ""
+"Want to talk to someone about MDN? There are a few ways you can do that:"
+msgstr ""
+"Dëshironi të bisedoni me dikë rreth MDN-së? Ka disa mënyra për ta bërë këtë:"
 
 #: kuma/users/templates/users/email/welcome/html.ltxt:38
 #, python-format
-msgid "Mailing list: <a href=\"%(list_link)s\">subscribe</a> to tell us about what you're interested in on MDN and ask questions about the site."
-msgstr "Listë postimesh: <a href=\"%(list_link)s\">pajtohuni</a> që të na tregoni se çfarë ju intereson te MDN-ja dhe që të bëni pyetje rreth sajtit."
+msgid ""
+"Mailing list: <a href=\"%(list_link)s\">subscribe</a> to tell us about what "
+"you're interested in on MDN and ask questions about the site."
+msgstr ""
+"Listë postimesh: <a href=\"%(list_link)s\">pajtohuni</a> që të na tregoni se"
+" çfarë ju intereson te MDN-ja dhe që të bëni pyetje rreth sajtit."
 
 #: kuma/users/templates/users/email/welcome/html.ltxt:43
 #, python-format
 msgid ""
-"Real-time chat: <a href=\"%(channel_link)s\">#mdn channel on irc.mozilla.org</a>. (Get more info about <a href=\"%(irc_link)s\">IRC</a>.) You can find the MDN writing staff admins there: Eric "
-"Shepherd (sheppy), Jean-Yves Perrier (teoli), Will Bamberg (wbamberg), Florian Scholz (fscholz), Chris Mills (chrismills), and me (jms), MDN's community manager."
+"Real-time chat: <a href=\"%(channel_link)s\">#mdn channel on "
+"irc.mozilla.org</a>. (Get more info about <a href=\"%(irc_link)s\">IRC</a>.)"
+" You can find the MDN writing staff admins there: Eric Shepherd (sheppy), "
+"Jean-Yves Perrier (teoli), Will Bamberg (wbamberg), Florian Scholz "
+"(fscholz), Chris Mills (chrismills), and me (jms), MDN's community manager."
 msgstr ""
-"Fjalosje e atëçastshme: <a href=\"%(channel_link)s\">kanali #mdn te irc.mozilla.org</a>. (Merrni më tepër të dhëna rreth <a href=\"%(irc_link)s\">IRC-së</a>.) Përgjegjësit e MDN-së për shkrime i "
-"gjeni këtu: Eric Shepherd (sheppy), Jean-Yves Perrier (teoli), Will Bamberg (wbamberg), Florian Scholz (fscholz), Chris Mills (chrismills), dhe unë (jms), përgjegjësi i MDN-së për bashkësinë."
+"Fjalosje e atëçastshme: <a href=\"%(channel_link)s\">kanali #mdn te "
+"irc.mozilla.org</a>. (Merrni më tepër të dhëna rreth <a href=\"%(irc_link)s"
+"\">IRC-së</a>.) Përgjegjësit e MDN-së për shkrime i gjeni këtu: Eric "
+"Shepherd (sheppy), Jean-Yves Perrier (teoli), Will Bamberg (wbamberg), "
+"Florian Scholz (fscholz), Chris Mills (chrismills), dhe unë (jms), "
+"përgjegjësi i MDN-së për bashkësinë."
 
 #: kuma/users/templates/users/email/welcome/html.ltxt:51
 #, python-format
-msgid "Blog: On the <a href=\"%(blog_link)s\">about:community</a> blog, look for the posts tagged with <a href=\"%(tagged_link)s\">Developer Engagement</a>."
-msgstr "Blog: Te blogu <a href=\"%(blog_link)s\">about:community</a> shihni për postime të etiketuar me <a href=\"%(tagged_link)s\">Developer Engagement</a>."
+msgid ""
+"Blog: On the <a href=\"%(blog_link)s\">about:community</a> blog, look for "
+"the posts tagged with <a href=\"%(tagged_link)s\">Developer Engagement</a>."
+msgstr ""
+"Blog: Te blogu <a href=\"%(blog_link)s\">about:community</a> shihni për "
+"postime të etiketuar me <a href=\"%(tagged_link)s\">Developer "
+"Engagement</a>."
 
 #. This is an email. Whitespace matters!
-#: kuma/users/templates/users/email/welcome/html.ltxt:60 kuma/users/templates/users/email/welcome/plain.ltxt:51
-msgid "Don't be shy, if you have any doubt, problems, questions: contact us! We are here to help."
-msgstr "Mos jini i turpshëm, nëse keni ndonjë mëdyshje, probleme, pyetje: lidhuni me ne! Jemi këtu për t’ju ndihmuar."
+#: kuma/users/templates/users/email/welcome/html.ltxt:60
+#: kuma/users/templates/users/email/welcome/plain.ltxt:51
+msgid ""
+"Don't be shy, if you have any doubt, problems, questions: contact us! We are"
+" here to help."
+msgstr ""
+"Mos jini i turpshëm, nëse keni ndonjë mëdyshje, probleme, pyetje: lidhuni me"
+" ne! Jemi këtu për t’ju ndihmuar."
 
 #. This is an email. Whitespace matters!
 #: kuma/users/templates/users/email/welcome/plain.ltxt:4
@@ -3802,17 +4701,24 @@ msgstr "Njatjeta %(username)s"
 
 #. This is an email. Whitespace matters!
 #: kuma/users/templates/users/email/welcome/plain.ltxt:7
-msgid "Thanks for creating a profile on Mozilla Developer Network (MDN) -- a community making great resources for developers like you."
-msgstr "Faleminderit që krijuar një profil te Rrjeti i Zhvilluesve Mozilla (MDN) -- një bashkësi që krijon burime të shkëlqyera për zhvillues si ju."
+msgid ""
+"Thanks for creating a profile on Mozilla Developer Network (MDN) -- a "
+"community making great resources for developers like you."
+msgstr ""
+"Faleminderit që krijuar një profil te Rrjeti i Zhvilluesve Mozilla (MDN) -- "
+"një bashkësi që krijon burime të shkëlqyera për zhvillues si ju."
 
 #. This is an email. Whitespace matters!
 #: kuma/users/templates/users/email/welcome/plain.ltxt:10
 msgid ""
-"You've completed the first step of Getting Started on MDN by creating a profile. Now, keep going by picking a task on MDN, and doing it! We have a bunch of intro tasks you can choose based on your "
-"interests."
+"You've completed the first step of Getting Started on MDN by creating a "
+"profile. Now, keep going by picking a task on MDN, and doing it! We have a "
+"bunch of intro tasks you can choose based on your interests."
 msgstr ""
-"Duke krijuar një profil plotësuat hapin e parë të Si T’ia FIllohet te MDN-ja. Tani, vazhdoni duke zgjedhur një punë te MDN-ja, dhe duke e kryer atë! Kemi një dorë punësh fillestarësh prej nga mund "
-"të zgjidhni duke u bazuar në interesat tuaja."
+"Duke krijuar një profil plotësuat hapin e parë të Si T’ia FIllohet te MDN-"
+"ja. Tani, vazhdoni duke zgjedhur një punë te MDN-ja, dhe duke e kryer atë! "
+"Kemi një dorë punësh fillestarësh prej nga mund të zgjidhni duke u bazuar në"
+" interesat tuaja."
 
 #. This is an email. Whitespace matters!
 #: kuma/users/templates/users/email/welcome/plain.ltxt:14
@@ -3842,8 +4748,12 @@ msgstr "Listë postimesh: %(list_link)s"
 
 #. This is an email. Whitespace matters!
 #: kuma/users/templates/users/email/welcome/plain.ltxt:36
-msgid "Subscribe to tell us about what you're interested in on MDN and ask questions about the site."
-msgstr "Pajtohuni që të na tregoni se ç’ju intereson te MDN-ja dhe që të bëni pyetje rreth sajtit."
+msgid ""
+"Subscribe to tell us about what you're interested in on MDN and ask "
+"questions about the site."
+msgstr ""
+"Pajtohuni që të na tregoni se ç’ju intereson te MDN-ja dhe që të bëni pyetje"
+" rreth sajtit."
 
 #. This is an email. Whitespace matters!
 #: kuma/users/templates/users/email/welcome/plain.ltxt:39
@@ -3859,11 +4769,14 @@ msgstr "Shihni %(irc_link)s për më tepër të dhëna mbi IRC-në."
 #. This is an email. Whitespace matters!
 #: kuma/users/templates/users/email/welcome/plain.ltxt:45
 msgid ""
-"You can find the MDN writing staff admins there: Eric Shepherd (sheppy), Jean-Yves Perrier (teoli), Will Bamberg (wbamberg), Florian Scholz (fscholz), Chris Mills (chrismills), and me (jms), MDN's "
-"community manager."
+"You can find the MDN writing staff admins there: Eric Shepherd (sheppy), "
+"Jean-Yves Perrier (teoli), Will Bamberg (wbamberg), Florian Scholz "
+"(fscholz), Chris Mills (chrismills), and me (jms), MDN's community manager."
 msgstr ""
-"Përgjegjësit e MDN-së për shkrimin e artikujve mund t’i gjeni këtu: Eric Shepherd (sheppy), Jean-Yves Perrier (teoli), Will Bamberg (wbamberg), Florian Scholz (fscholz), Chris Mills (chrismills), "
-"dhe unë (jms), përgjegjësi i MDN-së për bashkësinë."
+"Përgjegjësit e MDN-së për shkrimin e artikujve mund t’i gjeni këtu: Eric "
+"Shepherd (sheppy), Jean-Yves Perrier (teoli), Will Bamberg (wbamberg), "
+"Florian Scholz (fscholz), Chris Mills (chrismills), dhe unë (jms), "
+"përgjegjësi i MDN-së për bashkësinë."
 
 #. This is an email. Whitespace matters!
 #: kuma/users/templates/users/email/welcome/plain.ltxt:48
@@ -3871,7 +4784,8 @@ msgstr ""
 msgid "Blog: %(blog_link)s"
 msgstr "Blog: %(blog_link)s"
 
-#: kuma/wiki/apps.py:56 kuma/wiki/templates/admin/wiki/purge_documents.html:23 kuma/wiki/templates/admin/wiki/document/load_data_form.html:23
+#: kuma/wiki/apps.py:56 kuma/wiki/templates/admin/wiki/purge_documents.html:23
+#: kuma/wiki/templates/admin/wiki/document/load_data_form.html:23
 msgid "Wiki"
 msgstr "Wiki"
 
@@ -3961,13 +4875,21 @@ msgstr "Ju lutemi, jepni një titull."
 
 #: kuma/wiki/forms.py:31
 #, python-format
-msgid "The title is too short (%(show_value)s characters). It must be at least %(limit_value)s characters."
-msgstr "Titulli është shumë i shkurtër (%(show_value)s characters). Duhet të jetë e pakta %(limit_value)s shenja."
+msgid ""
+"The title is too short (%(show_value)s characters). It must be at least "
+"%(limit_value)s characters."
+msgstr ""
+"Titulli është shumë i shkurtër (%(show_value)s characters). Duhet të jetë e "
+"pakta %(limit_value)s shenja."
 
 #: kuma/wiki/forms.py:33
 #, python-format
-msgid "Please keep the length of the title to %(limit_value)s characters or less. It is currently %(show_value)s characters."
-msgstr "Ju lutemi, mbajeni gjatësinë e titullit %(limit_value)s ose më pak shenja. Tani është %(show_value)s shenja."
+msgid ""
+"Please keep the length of the title to %(limit_value)s characters or less. "
+"It is currently %(show_value)s characters."
+msgstr ""
+"Ju lutemi, mbajeni gjatësinë e titullit %(limit_value)s ose më pak shenja. "
+"Tani është %(show_value)s shenja."
 
 #: kuma/wiki/forms.py:36
 msgid "Name Your Article"
@@ -3983,13 +4905,21 @@ msgstr "Identifikuesi i dhënë s’është i vlefshëm."
 
 #: kuma/wiki/forms.py:39
 #, python-format
-msgid "The slug is too short (%(show_value)s characters). It must be at least %(limit_value)s characters."
-msgstr "Identifikuesi është shumë i shkurtër (%(show_value)s shenja). Duhet të jetë e pakta %(limit_value)s shenja."
+msgid ""
+"The slug is too short (%(show_value)s characters). It must be at least "
+"%(limit_value)s characters."
+msgstr ""
+"Identifikuesi është shumë i shkurtër (%(show_value)s shenja). Duhet të jetë "
+"e pakta %(limit_value)s shenja."
 
 #: kuma/wiki/forms.py:41
 #, python-format
-msgid "Please keep the length of the slug to %(limit_value)s characters or less. It is currently %(show_value)s characters."
-msgstr "Ju lutemi, mbajeni gjatësinë e identifikuesit %(limit_value)s ose më pak shenja. Tani është %(show_value)s shenja."
+msgid ""
+"Please keep the length of the slug to %(limit_value)s characters or less. It"
+" is currently %(show_value)s characters."
+msgstr ""
+"Ju lutemi, mbajeni gjatësinë e identifikuesit %(limit_value)s ose më pak "
+"shenja. Tani është %(show_value)s shenja."
 
 #: kuma/wiki/forms.py:44
 msgid "Please provide a summary."
@@ -3997,13 +4927,21 @@ msgstr "Ju lutemi, jepni një përmbledhje."
 
 #: kuma/wiki/forms.py:45
 #, python-format
-msgid "The summary is too short (%(show_value)s characters). It must be at least %(limit_value)s characters."
-msgstr "Përmbledhja është shumë e shkurtër (%(show_value)s shenja). Duhet të jetë të paktën %(limit_value)s shenja."
+msgid ""
+"The summary is too short (%(show_value)s characters). It must be at least "
+"%(limit_value)s characters."
+msgstr ""
+"Përmbledhja është shumë e shkurtër (%(show_value)s shenja). Duhet të jetë të"
+" paktën %(limit_value)s shenja."
 
 #: kuma/wiki/forms.py:47
 #, python-format
-msgid "Please keep the length of the summary to %(limit_value)s characters or less. It is currently %(show_value)s characters."
-msgstr "Ju lutemi, mbajeni gjatësinë e përmbledhjes %(limit_value)s ose më pak shenja. Tani është %(show_value)s shenja."
+msgid ""
+"Please keep the length of the summary to %(limit_value)s characters or less."
+" It is currently %(show_value)s characters."
+msgstr ""
+"Ju lutemi, mbajeni gjatësinë e përmbledhjes %(limit_value)s ose më pak "
+"shenja. Tani është %(show_value)s shenja."
 
 #: kuma/wiki/forms.py:50
 msgid "Please provide content."
@@ -4011,18 +4949,30 @@ msgstr "Ju lutemi, jepni lëndë."
 
 #: kuma/wiki/forms.py:51
 #, python-format
-msgid "The content is too short (%(show_value)s characters). It must be at least %(limit_value)s characters."
-msgstr "Lënda është shumë e shkurtët (%(show_value)s shenja). Duhet të jetë të paktën %(limit_value)s shenja."
+msgid ""
+"The content is too short (%(show_value)s characters). It must be at least "
+"%(limit_value)s characters."
+msgstr ""
+"Lënda është shumë e shkurtët (%(show_value)s shenja). Duhet të jetë të "
+"paktën %(limit_value)s shenja."
 
 #: kuma/wiki/forms.py:53
 #, python-format
-msgid "Please keep the length of the content to %(limit_value)s characters or less. It is currently %(show_value)s characters."
-msgstr "Ju lutemi, mbajeni gjatësinë e lëndës %(limit_value)s ose më pak shenja. Tani është %(show_value)s shenja."
+msgid ""
+"Please keep the length of the content to %(limit_value)s characters or less."
+" It is currently %(show_value)s characters."
+msgstr ""
+"Ju lutemi, mbajeni gjatësinë e lëndës %(limit_value)s ose më pak shenja. "
+"Tani është %(show_value)s shenja."
 
 #: kuma/wiki/forms.py:56
 #, python-format
-msgid "Please keep the length of the comment to %(limit_value)s characters or less. It is currently %(show_value)s characters."
-msgstr "Ju lutemi, mbajeni gjatësinë e komentit %(limit_value)s ose më pak shenja. Tani është %(show_value)s shenja."
+msgid ""
+"Please keep the length of the comment to %(limit_value)s characters or less."
+" It is currently %(show_value)s characters."
+msgstr ""
+"Ju lutemi, mbajeni gjatësinë e komentit %(limit_value)s ose më pak shenja. "
+"Tani është %(show_value)s shenja."
 
 #: kuma/wiki/forms.py:59
 msgid "Another document with this slug already exists."
@@ -4038,10 +4988,17 @@ msgstr "Ky dokument është modifikuar, ndërkohë që po e përpunonit."
 
 #: kuma/wiki/forms.py:64
 msgid "Changing this document's slug requires moving it and its children."
-msgstr "Ndryshimi i identifikuesit të këtij dokumenti lyp lëvizjen e tij dhe të pjellave të tij."
+msgstr ""
+"Ndryshimi i identifikuesit të këtij dokumenti lyp lëvizjen e tij dhe të "
+"pjellave të tij."
 
-#: kuma/wiki/forms.py:80 kuma/wiki/forms.py:169 kuma/wiki/forms.py:553 kuma/wiki/templates/wiki/create.html:42 kuma/wiki/templates/wiki/edit.html:68 kuma/wiki/templates/wiki/edit.html:117
-#: kuma/wiki/templates/wiki/move.html:60 kuma/wiki/templates/wiki/includes/document_macros.html:66 kuma/wiki/templates/wiki/includes/translate_description.html:11
+#: kuma/wiki/forms.py:80 kuma/wiki/forms.py:169 kuma/wiki/forms.py:553
+#: kuma/wiki/templates/wiki/create.html:42
+#: kuma/wiki/templates/wiki/edit.html:68
+#: kuma/wiki/templates/wiki/edit.html:117
+#: kuma/wiki/templates/wiki/move.html:60
+#: kuma/wiki/templates/wiki/includes/document_macros.html:66
+#: kuma/wiki/templates/wiki/includes/translate_description.html:11
 msgid "Title:"
 msgstr "Titull:"
 
@@ -4049,7 +5006,9 @@ msgstr "Titull:"
 msgid "Title of article"
 msgstr "Titulli i artikullit"
 
-#: kuma/wiki/forms.py:89 kuma/wiki/forms.py:183 kuma/wiki/templates/wiki/create.html:46 kuma/wiki/templates/wiki/includes/document_macros.html:70
+#: kuma/wiki/forms.py:89 kuma/wiki/forms.py:183
+#: kuma/wiki/templates/wiki/create.html:46
+#: kuma/wiki/templates/wiki/includes/document_macros.html:70
 #: kuma/wiki/templates/wiki/includes/translate_description.html:22
 msgid "Slug:"
 msgstr "Identifikues:"
@@ -4066,11 +5025,14 @@ msgstr "Kategori:"
 msgid "Type of article"
 msgstr "Lloj artikulli"
 
-#: kuma/wiki/forms.py:106 kuma/wiki/templates/wiki/create.html:50 kuma/wiki/templates/wiki/includes/translate_description.html:33
+#: kuma/wiki/forms.py:106 kuma/wiki/templates/wiki/create.html:50
+#: kuma/wiki/templates/wiki/includes/translate_description.html:33
 msgid "Parent:"
 msgstr "Prind:"
 
-#: kuma/wiki/forms.py:194 kuma/wiki/templates/wiki/edit.html:74 kuma/wiki/templates/wiki/includes/document_macros.html:75 kuma/wiki/templates/wiki/includes/document_tag.html:4
+#: kuma/wiki/forms.py:194 kuma/wiki/templates/wiki/edit.html:74
+#: kuma/wiki/templates/wiki/includes/document_macros.html:75
+#: kuma/wiki/templates/wiki/includes/document_tag.html:4
 msgid "Tags:"
 msgstr "Etiketa:"
 
@@ -4090,7 +5052,8 @@ msgstr "Përmbledhje përfundimesh kërkimi:"
 msgid "Only displayed on search results page"
 msgstr "Shfaqur vetëm në faqen e përfundimeve të kërkimit"
 
-#: kuma/wiki/forms.py:220 kuma/wiki/templates/wiki/edit.html:92 kuma/wiki/templates/wiki/includes/document_macros.html:80
+#: kuma/wiki/forms.py:220 kuma/wiki/templates/wiki/edit.html:92
+#: kuma/wiki/templates/wiki/includes/document_macros.html:80
 msgid "Content:"
 msgstr "Lëndë:"
 
@@ -4114,7 +5077,8 @@ msgstr "Identifikues i ri:"
 msgid "New article URL"
 msgstr "URL e re artikulli"
 
-#: kuma/wiki/helpers.py:100 kuma/wiki/helpers.py:101 kuma/wiki/helpers.py:116 kuma/wiki/helpers.py:117
+#: kuma/wiki/helpers.py:100 kuma/wiki/helpers.py:101 kuma/wiki/helpers.py:116
+#: kuma/wiki/helpers.py:117
 #, python-format
 msgid "Revision %s"
 msgstr "Rishikimi %s"
@@ -4186,8 +5150,12 @@ msgstr "H4 dhe më të lartë"
 
 #: kuma/wiki/models.py:1670
 #, python-format
-msgid "A revision must be based on a revision of the %(locale)s document. Revision ID %(id)s does not fit those criteria."
-msgstr "Rishikimet duhet të bazohen mbi një rishikim të dokumentit në %(locale)s. Rishikimi me ID %(id)s s’e plotëson këtë kusht."
+msgid ""
+"A revision must be based on a revision of the %(locale)s document. Revision "
+"ID %(id)s does not fit those criteria."
+msgstr ""
+"Rishikimet duhet të bazohen mbi një rishikim të dokumentit në %(locale)s. "
+"Rishikimi me ID %(id)s s’e plotëson këtë kusht."
 
 #: kuma/wiki/models.py:1832
 msgid "Slug"
@@ -4199,15 +5167,22 @@ msgstr "Dokument (në dëshirë)"
 
 #: kuma/wiki/search.py:310
 #, python-format
-msgid "Indexing %(total)d documents into %(total_chunks)d chunks of size %(size)d into index %(index)s.total"
-msgstr "Po indeksohen %(total)d dokumente në %(total_chunks)d copa me madhësi %(size)d te treguesi %(index)s.total"
+msgid ""
+"Indexing %(total)d documents into %(total_chunks)d chunks of size %(size)d "
+"into index %(index)s.total"
+msgstr ""
+"Po indeksohen %(total)d dokumente në %(total_chunks)d copa me madhësi "
+"%(size)d te treguesi %(index)s.total"
 
-#: kuma/wiki/templates/admin/wiki/purge_documents.html:4 kuma/wiki/templates/admin/wiki/purge_documents.html:25 kuma/wiki/templates/admin/wiki/purge_documents.html:30
+#: kuma/wiki/templates/admin/wiki/purge_documents.html:4
+#: kuma/wiki/templates/admin/wiki/purge_documents.html:25
+#: kuma/wiki/templates/admin/wiki/purge_documents.html:30
 #: kuma/wiki/templates/admin/wiki/purge_documents.html:54
 msgid "Purge documents"
 msgstr "Pastro dokumentet"
 
-#: kuma/wiki/templates/admin/wiki/purge_documents.html:24 kuma/wiki/templates/admin/wiki/document/load_data_form.html:24
+#: kuma/wiki/templates/admin/wiki/purge_documents.html:24
+#: kuma/wiki/templates/admin/wiki/document/load_data_form.html:24
 msgid "Documents"
 msgstr "Dokumente"
 
@@ -4230,7 +5205,9 @@ msgstr "\"Ngarkoni dokumente\""
 msgid "Add %(name)s"
 msgstr "Shtoje %(name)s"
 
-#: kuma/wiki/templates/admin/wiki/document/load_data_form.html:4 kuma/wiki/templates/admin/wiki/document/load_data_form.html:25 kuma/wiki/templates/admin/wiki/document/load_data_form.html:30
+#: kuma/wiki/templates/admin/wiki/document/load_data_form.html:4
+#: kuma/wiki/templates/admin/wiki/document/load_data_form.html:25
+#: kuma/wiki/templates/admin/wiki/document/load_data_form.html:30
 msgid "Load documents"
 msgstr "Ngarko dokumente"
 
@@ -4264,7 +5241,8 @@ msgstr "Fshini Dokumente | %(document)s"
 msgid "Cannot delete pages with children until we fix this bug:"
 msgstr "S’fshihen dot faqe me pjella, pa u ndrequr kjo e metë:"
 
-#: kuma/wiki/templates/wiki/confirm_document_delete.html:17 kuma/wiki/templates/wiki/confirm_revision_revert.html:21
+#: kuma/wiki/templates/wiki/confirm_document_delete.html:17
+#: kuma/wiki/templates/wiki/confirm_revision_revert.html:21
 msgid "Creator"
 msgstr "Krijues"
 
@@ -4281,8 +5259,12 @@ msgid "Last Change Date"
 msgstr "Datë e Ndryshimit të Fundit"
 
 #: kuma/wiki/templates/wiki/confirm_document_delete.html:29
-msgid "You are about to delete this document and all of its revisions. Please let us know why this page should be deleted."
-msgstr "Ju ndan një hap nga fshirja e këtij dokumenti dhe e krejt rishikimeve të tij. Ju lutemi, na tregoni përse duhet fshirë kjo faqe."
+msgid ""
+"You are about to delete this document and all of its revisions. Please let "
+"us know why this page should be deleted."
+msgstr ""
+"Ju ndan një hap nga fshirja e këtij dokumenti dhe e krejt rishikimeve të "
+"tij. Ju lutemi, na tregoni përse duhet fshirë kjo faqe."
 
 #: kuma/wiki/templates/wiki/confirm_document_delete.html:36
 msgid "Are you sure you want to continue?"
@@ -4310,8 +5292,12 @@ msgid "Why are you reverting to this revision?"
 msgstr "Pse po e riktheni te ky rishikim?"
 
 #: kuma/wiki/templates/wiki/confirm_revision_revert.html:36
-msgid "You are about to revert the document to this revision. Click \"revert\" to revert to the content&nbsp;above."
-msgstr "Ju ndan një hap nga rikthimi i dokumentit te ky version. Klikoni mbi \"riktheje\" që të rikthehet te lënda&nbsp;më&nbsp;sipër."
+msgid ""
+"You are about to revert the document to this revision. Click \"revert\" to "
+"revert to the content&nbsp;above."
+msgstr ""
+"Ju ndan një hap nga rikthimi i dokumentit te ky version. Klikoni mbi "
+"\"riktheje\" që të rikthehet te lënda&nbsp;më&nbsp;sipër."
 
 #: kuma/wiki/templates/wiki/create.html:6
 msgid "Create a New Template"
@@ -4329,7 +5315,8 @@ msgstr "Krijoni një"
 msgid "New Document"
 msgstr "Dokument i Ri"
 
-#: kuma/wiki/templates/wiki/create.html:36 kuma/wiki/templates/wiki/edit.html:108
+#: kuma/wiki/templates/wiki/create.html:36
+#: kuma/wiki/templates/wiki/edit.html:108
 msgid "Draft"
 msgstr "Skicë"
 
@@ -4337,7 +5324,8 @@ msgstr "Skicë"
 msgid "URL segment that identifies the page"
 msgstr "Segmenti URL që identifikon këtë faqe"
 
-#: kuma/wiki/templates/wiki/deletion_log.html:2 kuma/wiki/templates/wiki/deletion_log.html:7
+#: kuma/wiki/templates/wiki/deletion_log.html:2
+#: kuma/wiki/templates/wiki/deletion_log.html:7
 msgid "Document Deleted"
 msgstr "Dokumenti u Fshi"
 
@@ -4354,11 +5342,13 @@ msgstr "Arsye Për Fshirjen"
 msgid "Restore this document"
 msgstr "Riktheje këtë dokument"
 
-#: kuma/wiki/templates/wiki/document.html:86 templates/includes/lang_switcher.html:2
+#: kuma/wiki/templates/wiki/document.html:86
+#: templates/includes/lang_switcher.html:2
 msgid "Other languages:"
 msgstr "Gjuhë të tjera:"
 
-#: kuma/wiki/templates/wiki/document.html:97 templates/includes/lang_switcher.html:15
+#: kuma/wiki/templates/wiki/document.html:97
+#: templates/includes/lang_switcher.html:15
 msgid "Go"
 msgstr "Shko tek"
 
@@ -4366,7 +5356,8 @@ msgstr "Shko tek"
 msgid "Previous Search Result"
 msgstr "Përfundimi i Mëparshëm i Kërkimit"
 
-#: kuma/wiki/templates/wiki/document.html:166 kuma/wiki/templates/wiki/document.html:176
+#: kuma/wiki/templates/wiki/document.html:166
+#: kuma/wiki/templates/wiki/document.html:176
 msgid "No Previous Search Result"
 msgstr "Pa Përfundim të Mëparshëm Kërkimi"
 
@@ -4408,26 +5399,36 @@ msgstr "Në Këtë Artikull"
 
 #: kuma/wiki/templates/wiki/document.html:252
 #, python-format
-msgid "This document is being rendered for the first time by the system. Please <a href=\"%(url)s\">reload this page</a> in a few minutes to see full content."
-msgstr "Ky dokument po prodhohet për herë të parë nga sistemi. Ju lutemi, <a href=\"%(url)s\">ringarkojeni këtë faqe</a> pas pak minutash që të shihni lëndën e plotë."
+msgid ""
+"This document is being rendered for the first time by the system. Please <a "
+"href=\"%(url)s\">reload this page</a> in a few minutes to see full content."
+msgstr ""
+"Ky dokument po prodhohet për herë të parë nga sistemi. Ju lutemi, <a "
+"href=\"%(url)s\">ringarkojeni këtë faqe</a> pas pak minutash që të shihni "
+"lëndën e plotë."
 
 #: kuma/wiki/templates/wiki/document.html:260
 #, python-format
 msgid ""
-"An update to this document <abbr title=\"%(started_at)s\">is currently in progress</abbr>. If the content below seems stale or if something is missing, please <a href=\"%(url)s\">reload this page</"
-"a> in a few minutes."
+"An update to this document <abbr title=\"%(started_at)s\">is currently in "
+"progress</abbr>. If the content below seems stale or if something is "
+"missing, please <a href=\"%(url)s\">reload this page</a> in a few minutes."
 msgstr ""
-"Për këtë dokument <abbr title=\"%(started_at)s\">ka një përditësim në kryerje e sipër</abbr>. Nëse lënda më poshtë duke e vjetruar ose i mungon diçka, ju lutemi, <a href=\"%(url)s\">ringarkojeni "
-"këtë faqe</a> pas pak minutash."
+"Për këtë dokument <abbr title=\"%(started_at)s\">ka një përditësim në "
+"kryerje e sipër</abbr>. Nëse lënda më poshtë duke e vjetruar ose i mungon "
+"diçka, ju lutemi, <a href=\"%(url)s\">ringarkojeni këtë faqe</a> pas pak "
+"minutash."
 
 #: kuma/wiki/templates/wiki/document.html:269
 #, python-format
 msgid ""
-"An update to this document <abbr title=\"%(scheduled_at)s\">has been scheduled</abbr>. If the content below seems stale or if something is missing, please <a href=\"%(url)s\">reload this page</a> "
-"in a few minutes."
+"An update to this document <abbr title=\"%(scheduled_at)s\">has been "
+"scheduled</abbr>. If the content below seems stale or if something is "
+"missing, please <a href=\"%(url)s\">reload this page</a> in a few minutes."
 msgstr ""
-"Për këtë dokument <abbr title=\"%(scheduled_at)s\">është planifikuar një përditësim</abbr>. Nëse lënda më poshtë duke e vjetruar ose i mungon diçka, ju lutemi, <a href=\"%(url)s\">ringarkojeni këtë "
-"faqe</a> pas pak minutash."
+"Për këtë dokument <abbr title=\"%(scheduled_at)s\">është planifikuar një "
+"përditësim</abbr>. Nëse lënda më poshtë duke e vjetruar ose i mungon diçka, "
+"ju lutemi, <a href=\"%(url)s\">ringarkojeni këtë faqe</a> pas pak minutash."
 
 #: kuma/wiki/templates/wiki/document.html:285
 msgid "This article is in need of a technical review."
@@ -4439,8 +5440,12 @@ msgstr "Ky artikull ka nevojë për shqyrtim redaktorial."
 
 #: kuma/wiki/templates/wiki/document.html:296
 #, python-format
-msgid "This translation is incomplete. Please help <a href=\"%(translate_url)s\">translate this article</a> from English."
-msgstr "Ky përkthim është i paplotë. Ju lutemi, ndihmoni <a href=\"%(translate_url)s\">të përkthehet ky artikull</a> nga Anglishtja."
+msgid ""
+"This translation is incomplete. Please help <a "
+"href=\"%(translate_url)s\">translate this article</a> from English."
+msgstr ""
+"Ky përkthim është i paplotë. Ju lutemi, ndihmoni <a "
+"href=\"%(translate_url)s\">të përkthehet ky artikull</a> nga Anglishtja."
 
 #: kuma/wiki/templates/wiki/document.html:301
 msgid "This translation is in progress."
@@ -4448,8 +5453,12 @@ msgstr "Përkthimi është në kryerje e sipër."
 
 #: kuma/wiki/templates/wiki/document.html:308
 #, fuzzy, python-format
-msgid "Our volunteers haven't translated this article into <bdi>%(locale)s</bdi> yet. <a href=\"%(help_link)s\">Join us and help get the job done!</a>"
-msgstr "Vullnetarët tanë s’e kanë përkthyer ende në %(locale)s këtë artikull. <a href=\"%(help_link)s\">Bashkohuni dhe ndihmoni të mbarohet kjo punë!</a>"
+msgid ""
+"Our volunteers haven't translated this article into <bdi>%(locale)s</bdi> "
+"yet. <a href=\"%(help_link)s\">Join us and help get the job done!</a>"
+msgstr ""
+"Vullnetarët tanë s’e kanë përkthyer ende në %(locale)s këtë artikull. <a "
+"href=\"%(help_link)s\">Bashkohuni dhe ndihmoni të mbarohet kjo punë!</a>"
 
 #: kuma/wiki/templates/wiki/document.html:319
 msgid "This article doesn't have any content yet."
@@ -4457,8 +5466,14 @@ msgstr "Ky artikull s’ka ende lëndë."
 
 #: kuma/wiki/templates/wiki/document.html:322
 #, python-format
-msgid "Search for <a href=\"%(search_link)s\" rel=\"nofollow, noindex\">pages that use %(title)s</a> to see example use cases and how many pages use this macro."
-msgstr "Kërkoni për <a href=\"%(search_link)s\" rel=\"nofollow, noindex\">faqe që përdorin %(title)s</a> që të shihni shembuj përdoruesish dhe se sa faqe e përdorin këtë makro."
+msgid ""
+"Search for <a href=\"%(search_link)s\" rel=\"nofollow, noindex\">pages that "
+"use %(title)s</a> to see example use cases and how many pages use this "
+"macro."
+msgstr ""
+"Kërkoni për <a href=\"%(search_link)s\" rel=\"nofollow, noindex\">faqe që "
+"përdorin %(title)s</a> që të shihni shembuj përdoruesish dhe se sa faqe e "
+"përdorin këtë makro."
 
 #: kuma/wiki/templates/wiki/document.html:335
 msgid "This article doesn't have approved content yet."
@@ -4492,20 +5507,28 @@ msgstr "%(title)s | Përpunoni Artikull"
 
 #: kuma/wiki/templates/wiki/edit.html:31
 msgid ""
-"Please review the differences between your changes and the changes saved since you started editing. You may save again, but try to resolve any conflicts by hand so that the changes made since you "
-"started are not lost."
+"Please review the differences between your changes and the changes saved "
+"since you started editing. You may save again, but try to resolve any "
+"conflicts by hand so that the changes made since you started are not lost."
 msgstr ""
-"Ju lutemi, shqyrtoni dallimet mes ndryshimeve tuaja dhe ndryshimet e ruajtura qëkur nisët të përpunonit. Mund të bëni sërish ruajtje, por përpiquni t’i jepni zgjidhje dorazi cilësdo përplasje , që "
-"kështu ndryshimet e bëra prej fillimeve tuaja të mos humbin."
+"Ju lutemi, shqyrtoni dallimet mes ndryshimeve tuaja dhe ndryshimet e "
+"ruajtura qëkur nisët të përpunonit. Mund të bëni sërish ruajtje, por "
+"përpiquni t’i jepni zgjidhje dorazi cilësdo përplasje , që kështu ndryshimet"
+" e bëra prej fillimeve tuaja të mos humbin."
 
 #: kuma/wiki/templates/wiki/edit.html:41
 msgid "Your Changes"
 msgstr "Ndryshimet Tuaja"
 
-#: kuma/wiki/templates/wiki/edit.html:43 kuma/wiki/templates/wiki/edit.html:55 kuma/wiki/templates/wiki/includes/document_macros.html:42 kuma/wiki/templates/wiki/includes/document_macros.html:58
+#: kuma/wiki/templates/wiki/edit.html:43 kuma/wiki/templates/wiki/edit.html:55
+#: kuma/wiki/templates/wiki/includes/document_macros.html:42
+#: kuma/wiki/templates/wiki/includes/document_macros.html:58
 #, python-format
-msgid "Revision %(id)s by <a href=\"%(user_profile_url)s\">%(user)s</a> on %(date)s"
-msgstr "Rishikimi %(id)s nga <a href=\"%(user_profile_url)s\">%(user)s</a> më %(date)s"
+msgid ""
+"Revision %(id)s by <a href=\"%(user_profile_url)s\">%(user)s</a> on %(date)s"
+msgstr ""
+"Rishikimi %(id)s nga <a href=\"%(user_profile_url)s\">%(user)s</a> më "
+"%(date)s"
 
 #: kuma/wiki/templates/wiki/edit.html:51
 msgid "Current Revision:"
@@ -4536,10 +5559,15 @@ msgid "Minutes"
 msgstr "Minuta"
 
 #: kuma/wiki/templates/wiki/edit.html:146
-msgid "Find the translation source with the lookup below and then click \"Save Changes.\""
-msgstr "Gjejeni burimin e përkthimit me kërkimin më poshtë dhe mandej klikoni mbi \"Ruaji Ndryshimet.\""
+msgid ""
+"Find the translation source with the lookup below and then click \"Save "
+"Changes.\""
+msgstr ""
+"Gjejeni burimin e përkthimit me kërkimin më poshtë dhe mandej klikoni mbi "
+"\"Ruaji Ndryshimet.\""
 
-#: kuma/wiki/templates/wiki/edit.html:148 kuma/wiki/templates/wiki/includes/translate_description.html:62
+#: kuma/wiki/templates/wiki/edit.html:148
+#: kuma/wiki/templates/wiki/includes/translate_description.html:62
 msgid "Lookup:"
 msgstr "Kërkim:"
 
@@ -4549,12 +5577,18 @@ msgstr "Faleminderit që harxhoni kohë për përmirësimin e MDN-së!"
 
 #: kuma/wiki/templates/wiki/edit.html:164
 #, python-format
-msgid "It looks like this is your first contribution to MDN. You can find answers to common editing questions within our <a target=\"_blank\" href=\"%(url)s\">Editor Guide</a>."
+msgid ""
+"It looks like this is your first contribution to MDN. You can find answers "
+"to common editing questions within our <a target=\"_blank\" "
+"href=\"%(url)s\">Editor Guide</a>."
 msgstr ""
-"Duket se ky është kontributi juaj i parë te MDN-ja. Për pyetje të rëndomta lidhur me përpunimet mund të gjeni përgjigje te <a target=\"_blank\" href=\"%(url)s\">Udhërrëfyesi ynë i Përpunuesit</a>."
+"Duket se ky është kontributi juaj i parë te MDN-ja. Për pyetje të rëndomta "
+"lidhur me përpunimet mund të gjeni përgjigje te <a target=\"_blank\" "
+"href=\"%(url)s\">Udhërrëfyesi ynë i Përpunuesit</a>."
 
 #: kuma/wiki/templates/wiki/edit.html:168
-msgid "Don't be afraid to break something, you can always revert your changes."
+msgid ""
+"Don't be afraid to break something, you can always revert your changes."
 msgstr "Mos kini frikë se prishni gjë, mundeni t’i zhbëni ndryshimet kurdo."
 
 #: kuma/wiki/templates/wiki/edit.html:169
@@ -4565,19 +5599,25 @@ msgstr "Dëfrehuni dhe jini krenar për kontributin tuaj!"
 msgid "Learn how to tag an article"
 msgstr "Mësoni si të etiketoni një artikull"
 
-#: kuma/wiki/templates/wiki/edit.html:190 kuma/wiki/templates/wiki/translate.html:112
+#: kuma/wiki/templates/wiki/edit.html:190
+#: kuma/wiki/templates/wiki/translate.html:112
 #, python-format
-msgid "Categorize the article. It will make the article findable under the right filters in the search engine. <a target=\"_blank\" href=\"%(url)s\">Read the Tagging Guide</a>."
+msgid ""
+"Categorize the article. It will make the article findable under the right "
+"filters in the search engine. <a target=\"_blank\" href=\"%(url)s\">Read the"
+" Tagging Guide</a>."
 msgstr ""
-"Jepini artikullit një kategori. Kjo do të ndihmojë në gjetjen e artikullit, kur përdoren filtrat e duhur, nga motorët e kërkimeve. <a target=\"_blank\" href=\"%(url)s\">Lexoni Udhërrëfyesin e "
-"Etiketimeve</a>."
+"Jepini artikullit një kategori. Kjo do të ndihmojë në gjetjen e artikullit, "
+"kur përdoren filtrat e duhur, nga motorët e kërkimeve. <a target=\"_blank\" "
+"href=\"%(url)s\">Lexoni Udhërrëfyesin e Etiketimeve</a>."
 
 #: kuma/wiki/templates/wiki/feed_docs_updated.html:3
 #, python-format
 msgid "View %(locale)s parent"
 msgstr "Shihni prindin në %(locale)s"
 
-#: kuma/wiki/templates/wiki/feed_docs_updated.html:5 kuma/wiki/templates/wiki/feed_docs_updated.html:11
+#: kuma/wiki/templates/wiki/feed_docs_updated.html:5
+#: kuma/wiki/templates/wiki/feed_docs_updated.html:11
 #, python-format
 msgid "last modified at %(modified)s"
 msgstr "ndryshuar së fundi më %(modified)s"
@@ -4593,11 +5633,17 @@ msgid "Move Article | %(document)s"
 msgstr "Lëvizeni Artikullin | %(document)s"
 
 #: kuma/wiki/templates/wiki/move.html:20
-msgid "Please specify the new location for this page by filling out the fields below. Be sure your new destination follows these rules:"
-msgstr "Ju lutemi, përcaktoni vendin e ri për këtë faqe, duke plotësuar fushat më poshtë. Sigurohuni që vendi juaj i ri plotëson këto rregulla:"
+msgid ""
+"Please specify the new location for this page by filling out the fields "
+"below. Be sure your new destination follows these rules:"
+msgstr ""
+"Ju lutemi, përcaktoni vendin e ri për këtë faqe, duke plotësuar fushat më "
+"poshtë. Sigurohuni që vendi juaj i ri plotëson këto rregulla:"
 
 #: kuma/wiki/templates/wiki/move.html:22
-msgid "Make sure the location you specify is located immediately under an existing page."
+msgid ""
+"Make sure the location you specify is located immediately under an existing "
+"page."
 msgstr "Sigurohuni se vendi që jepni gjendet fill nën një faqe ekzistuese."
 
 #: kuma/wiki/templates/wiki/move.html:23
@@ -4609,12 +5655,19 @@ msgid "Enter only the part of the URL following \"/docs/\"."
 msgstr "Jepni vetëm pjesën e URL-së që pason \"/docs/\"."
 
 #: kuma/wiki/templates/wiki/move.html:25
-msgid "Don't include a trailing slash (this will be removed for you if you include it, but you should leave it out)."
-msgstr "Mos përfshini gjarpërushe (do të hiqet, po qe se futni të tillë, por e mira është të mos vendoset)."
+msgid ""
+"Don't include a trailing slash (this will be removed for you if you include "
+"it, but you should leave it out)."
+msgstr ""
+"Mos përfshini gjarpërushe (do të hiqet, po qe se futni të tillë, por e mira "
+"është të mos vendoset)."
 
 #: kuma/wiki/templates/wiki/move.html:31
-msgid "Your requested move cannot be completed due to the following slug conflicts:"
-msgstr "Lëvizja e kërkuar prej jush s’mund të plotësohet, për shkak të përplasjeve vijuese te identifikuesit:"
+msgid ""
+"Your requested move cannot be completed due to the following slug conflicts:"
+msgstr ""
+"Lëvizja e kërkuar prej jush s’mund të plotësohet, për shkak të përplasjeve "
+"vijuese te identifikuesit:"
 
 #: kuma/wiki/templates/wiki/move.html:54
 msgid "Current Slug:"
@@ -4660,9 +5713,14 @@ msgstr "U kërkua lëvizje faqeje"
 
 #: kuma/wiki/templates/wiki/move_requested.html:9
 #, python-format
-msgid "<h1>Page Move Scheduled</h1> <p>Moving %(old_slug)s to <a href=\"%(new_url)s\">%(new_slug)s</a></p> <p> You'll receive an email when it finishes, or if any errors occur during the move.</p>"
+msgid ""
+"<h1>Page Move Scheduled</h1> <p>Moving %(old_slug)s to <a "
+"href=\"%(new_url)s\">%(new_slug)s</a></p> <p> You'll receive an email when "
+"it finishes, or if any errors occur during the move.</p>"
 msgstr ""
-"<h1>Lëvizja e Faqes u Planifikua</h1> <p>Po kalohet %(old_slug)s te <a href=\"%(new_url)s\">%(new_slug)s</a></p> <p> Kur të përfundojë, ose nëse ndodh ndonjë gabim, do të merrni një email.</p>"
+"<h1>Lëvizja e Faqes u Planifikua</h1> <p>Po kalohet %(old_slug)s te <a "
+"href=\"%(new_url)s\">%(new_slug)s</a></p> <p> Kur të përfundojë, ose nëse "
+"ndodh ndonjë gabim, do të merrni një email.</p>"
 
 #: kuma/wiki/templates/wiki/preview.html:13
 msgid "This is a preview of an unsaved document."
@@ -4685,7 +5743,8 @@ msgstr "Lëndë Shqyrtimi"
 msgid "Revision Source"
 msgstr "Burim Shqyrtimi"
 
-#: kuma/wiki/templates/wiki/revision.html:74 kuma/wiki/templates/wiki/list/revisions.html:70
+#: kuma/wiki/templates/wiki/revision.html:74
+#: kuma/wiki/templates/wiki/list/revisions.html:70
 msgid "Revert to this revision"
 msgstr "Riktheje te ky rishikim"
 
@@ -4701,20 +5760,30 @@ msgstr "Përzgjidhni gjuhë për përkthim:"
 #: kuma/wiki/templates/wiki/sphinx.html:32
 #, python-format
 msgid ""
-"Content is available under a license specific to this project. &middot; <a href=\"%(about_url)s\">About MDN</a> &middot; <a href=\"//github.com/mozilla/kuma\">Contribute to the code</a> &middot; <a "
+"Content is available under a license specific to this project. &middot; <a "
+"href=\"%(about_url)s\">About MDN</a> &middot; <a "
+"href=\"//github.com/mozilla/kuma\">Contribute to the code</a> &middot; <a "
 "href=\"//www.mozilla.org/en-US/privacy\">Privacy policy</a>"
 msgstr ""
-"Lënda mund të përdoret sipas një licence specifike për këtë projekt. &middot; <a href=\"%(about_url)s\">Mbi MDN-në</a> &middot; <a href=\"//github.com/mozilla/kuma\">Kontribuoni te kodi</a> "
-"&middot; <a href=\"//www.mozilla.org/en-US/privacy\">Rregulla privatësie</a>"
+"Lënda mund të përdoret sipas një licence specifike për këtë projekt. "
+"&middot; <a href=\"%(about_url)s\">Mbi MDN-në</a> &middot; <a "
+"href=\"//github.com/mozilla/kuma\">Kontribuoni te kodi</a> &middot; <a "
+"href=\"//www.mozilla.org/en-US/privacy\">Rregulla privatësie</a>"
 
 #: kuma/wiki/templates/wiki/sphinx.html:43
 #, python-format
 msgid ""
-"&copy; 2005-2015 Mozilla Developer Network and individual contributors<br /> Content is available under a license specific to this project. &middot; <a href=\"%(about_url)s\">About MDN</a> &middot; "
-"<a href=\"//github.com/mozilla/kuma\">Contribute to the code</a> &middot; <a href=\"//www.mozilla.org/en-US/privacy\">Privacy policy</a>"
+"&copy; 2005-2015 Mozilla Developer Network and individual contributors<br />"
+" Content is available under a license specific to this project. &middot; <a "
+"href=\"%(about_url)s\">About MDN</a> &middot; <a "
+"href=\"//github.com/mozilla/kuma\">Contribute to the code</a> &middot; <a "
+"href=\"//www.mozilla.org/en-US/privacy\">Privacy policy</a>"
 msgstr ""
-"&copy; 2005-2015 Mozilla Developer Network dhe kontrbues individualë<br /> Lënda mund të përdoret sipas një licence specifike e këtij projekti. &middot; <a href=\"%(about_url)s\">Mbi MDN-në</a> "
-"&middot; <a href=\"//github.com/mozilla/kuma\">Kontribuoni me kod</a> &middot; <a href=\"//www.mozilla.org/en-US/privacy\">Rregulla privatësie</a>"
+"&copy; 2005-2015 Mozilla Developer Network dhe kontrbues individualë<br /> "
+"Lënda mund të përdoret sipas një licence specifike e këtij projekti. "
+"&middot; <a href=\"%(about_url)s\">Mbi MDN-në</a> &middot; <a "
+"href=\"//github.com/mozilla/kuma\">Kontribuoni me kod</a> &middot; <a "
+"href=\"//www.mozilla.org/en-US/privacy\">Rregulla privatësie</a>"
 
 #: kuma/wiki/templates/wiki/translate.html:7
 #, python-format
@@ -4812,7 +5881,8 @@ msgstr "Historik Artikulli:"
 #: kuma/wiki/templates/wiki/email/edited.ltxt:40
 #, python-format
 msgid "You are subscribed to edits on: %(title)s and all its sub-articles."
-msgstr "Jeni pajtuar te përpunime të: %(title)s dhe krejt nënartikujve të tij."
+msgstr ""
+"Jeni pajtuar te përpunime të: %(title)s dhe krejt nënartikujve të tij."
 
 #: kuma/wiki/templates/wiki/email/edited.ltxt:44
 #, python-format
@@ -4849,7 +5919,8 @@ msgstr "S’ka përkthime të këtij artikulli."
 msgid "Add a translation"
 msgstr "Shtoni një përkthim"
 
-#: kuma/wiki/templates/wiki/includes/buttons.html:43 kuma/wiki/templates/wiki/includes/buttons.html:46
+#: kuma/wiki/templates/wiki/includes/buttons.html:43
+#: kuma/wiki/templates/wiki/includes/buttons.html:46
 msgid "Watch"
 msgstr "Vëzhgojeni"
 
@@ -4897,14 +5968,20 @@ msgstr "Shihni edhe"
 msgid "Change Revisions"
 msgstr "Ndryshoni Rishikimet"
 
-#: kuma/wiki/templates/wiki/includes/document_macros.html:37 kuma/wiki/templates/wiki/includes/document_macros.html:53
+#: kuma/wiki/templates/wiki/includes/document_macros.html:37
+#: kuma/wiki/templates/wiki/includes/document_macros.html:53
 #, python-format
 msgid "Revision %(num)s:"
 msgstr "Rishikimi %(num)s:"
 
-#: kuma/wiki/templates/wiki/includes/document_macros.html:82 kuma/wiki/templates/wiki/includes/revision_diff_table.html:8
-msgid "The server is rendering the content comparison. Please refresh this page in a few minutes."
-msgstr "Shërbyesi po krijon krahasimin e lëndës. Ju lutemi, rifreskojeni këtë faqe pas pak minutash."
+#: kuma/wiki/templates/wiki/includes/document_macros.html:82
+#: kuma/wiki/templates/wiki/includes/revision_diff_table.html:8
+msgid ""
+"The server is rendering the content comparison. Please refresh this page in "
+"a few minutes."
+msgstr ""
+"Shërbyesi po krijon krahasimin e lëndës. Ju lutemi, rifreskojeni këtë faqe "
+"pas pak minutash."
 
 #: kuma/wiki/templates/wiki/includes/document_macros.html:107
 msgid "Share:"
@@ -4973,22 +6050,33 @@ msgstr "Tani jeni i pajtuar te versioni %(language)s i këtij artikulli."
 
 #: kuma/wiki/templates/wiki/includes/document_macros.html:163
 #, python-format
-msgid "You have been unsubscribed from the %(language)s version of this article."
+msgid ""
+"You have been unsubscribed from the %(language)s version of this article."
 msgstr "Jeni shpajtuar prej versionit %(language)s të këtij artikulli."
 
-#: kuma/wiki/templates/wiki/includes/document_toc_field.html:2 kuma/wiki/templates/wiki/includes/translate_description.html:50
+#: kuma/wiki/templates/wiki/includes/document_toc_field.html:2
+#: kuma/wiki/templates/wiki/includes/translate_description.html:50
 msgid "Generate table of contents"
 msgstr "Prodho tabelën e lëndës"
 
-#: kuma/wiki/templates/wiki/includes/document_toc_field.html:2 kuma/wiki/templates/wiki/includes/translate_description.html:50
+#: kuma/wiki/templates/wiki/includes/document_toc_field.html:2
+#: kuma/wiki/templates/wiki/includes/translate_description.html:50
 msgid "TOC:"
 msgstr "TEL:"
 
 #: kuma/wiki/templates/wiki/includes/kumascript_errors.html:3
-msgid "There was a scripting error on this page. While it is being addressed by site editors, you can view partial content below."
-msgid_plural "There were scripting errors on this page. While those are being addressed by site editors, you can view partial content below."
-msgstr[0] "Pati një gabim skriptimi në këtë faqe. Ndërkohë që ky po shihet nga përpunuesit e sajtit, mund ta shihni lëndën pjesërisht më poshtë."
-msgstr[1] "Pati gabime skriptimi në këtë faqe. Ndërkohë që ky po shihet nga përpunuesit e sajtit, mund ta shihni lëndën pjesërisht më poshtë."
+msgid ""
+"There was a scripting error on this page. While it is being addressed by "
+"site editors, you can view partial content below."
+msgid_plural ""
+"There were scripting errors on this page. While those are being addressed by"
+" site editors, you can view partial content below."
+msgstr[0] ""
+"Pati një gabim skriptimi në këtë faqe. Ndërkohë që ky po shihet nga "
+"përpunuesit e sajtit, mund ta shihni lëndën pjesërisht më poshtë."
+msgstr[1] ""
+"Pati gabime skriptimi në këtë faqe. Ndërkohë që ky po shihet nga përpunuesit"
+" e sajtit, mund ta shihni lëndën pjesërisht më poshtë."
 
 #: kuma/wiki/templates/wiki/includes/kumascript_errors.html:11
 msgid "Hide error information"
@@ -5001,9 +6089,14 @@ msgstr[0] "Më tepër të dhëna rreth këtij gabimi"
 msgstr[1] "Më tepër të dhëna rreth këtyre gabimeve"
 
 #: kuma/wiki/templates/wiki/includes/kumascript_errors.html:19
-msgid "Anyone with an MDN profile can edit a document to fix an error. Use the <a href=\"/docs/MDN/Kuma/Troubleshooting_KumaScript_errors\">KumaScript troubleshooting guide</a> as a starting point."
+msgid ""
+"Anyone with an MDN profile can edit a document to fix an error. Use the <a "
+"href=\"/docs/MDN/Kuma/Troubleshooting_KumaScript_errors\">KumaScript "
+"troubleshooting guide</a> as a starting point."
 msgstr ""
-"Cilido me profil te MDN-ja mund të përpunojë një dokument, për ndreqjen e një gabimi. Si pikënisje, përdorni <a href=\"/docs/MDN/Kuma/Troubleshooting_KumaScript_errors\">dhërrëfyesin për "
+"Cilido me profil te MDN-ja mund të përpunojë një dokument, për ndreqjen e "
+"një gabimi. Si pikënisje, përdorni <a "
+"href=\"/docs/MDN/Kuma/Troubleshooting_KumaScript_errors\">dhërrëfyesin për "
 "diagnostikime me KumaScript-in</a>."
 
 #: kuma/wiki/templates/wiki/includes/kumascript_errors.html:29
@@ -5075,22 +6168,35 @@ msgid "Learn how to use Revision Comments"
 msgstr "Mësoni si të përdorni Komente Rishikimi"
 
 #: kuma/wiki/templates/wiki/includes/revision_comment.html:3
-msgid "Tell us why you made additions and changes. It is optional, but will make page history easier to understand."
-msgstr "Tregonani pse bëtë shtesa dhe ndryshime. Kjo është opsionale, por do ta bëjë historikun e faqes më të lehtë për t’u kuptuar."
+msgid ""
+"Tell us why you made additions and changes. It is optional, but will make "
+"page history easier to understand."
+msgstr ""
+"Tregonani pse bëtë shtesa dhe ndryshime. Kjo është opsionale, por do ta bëjë"
+" historikun e faqes më të lehtë për t’u kuptuar."
 
 #: kuma/wiki/templates/wiki/includes/spam_error.html:2
 #, python-format
 msgid ""
-"Your submission includes content that may not be suitable for MDN. Repeated attempts to submit unsuitable material may result in your account being deactivated. See our guide “<a href="
-"\"%(does_this_belong_url)s\">Does this belong on MDN?</a>” for details on what constitutes appropriate material."
+"Your submission includes content that may not be suitable for MDN. Repeated "
+"attempts to submit unsuitable material may result in your account being "
+"deactivated. See our guide “<a href=\"%(does_this_belong_url)s\">Does this "
+"belong on MDN?</a>” for details on what constitutes appropriate material."
 msgstr ""
-"Parashtrimi juaj përfshin lëndë që mund të mos jetë e përshtatshme për MDN-në. Përpjekjet e përsëritura për të parashtruar material të papërshtatshëm mund të shpien në çaktivizimin e llogarisë "
-"suaj. Për hollësi mbi ç’përfaqëson material të përshtatshëm shihni udhërrëfyesin tonë “<a href=\"%(does_this_belong_url)s\">Does this belong on MDN?</a>”."
+"Parashtrimi juaj përfshin lëndë që mund të mos jetë e përshtatshme për MDN-"
+"në. Përpjekjet e përsëritura për të parashtruar material të papërshtatshëm "
+"mund të shpien në çaktivizimin e llogarisë suaj. Për hollësi mbi "
+"ç’përfaqëson material të përshtatshëm shihni udhërrëfyesin tonë “<a "
+"href=\"%(does_this_belong_url)s\">Does this belong on MDN?</a>”."
 
 #: kuma/wiki/templates/wiki/includes/spam_error.html:11
 #, python-format
-msgid "If you believe you’ve received this message by mistake, please <a href=\"%(admin_email)s\">contact the site administrators</a>."
-msgstr "Nëse besoni se e morët gabimisht këtë mesazh, ju lutemi <a href=\"%(admin_email)s\">lidhuni me përgjegjësit e sajtit</a>."
+msgid ""
+"If you believe you’ve received this message by mistake, please <a "
+"href=\"%(admin_email)s\">contact the site administrators</a>."
+msgstr ""
+"Nëse besoni se e morët gabimisht këtë mesazh, ju lutemi <a "
+"href=\"%(admin_email)s\">lidhuni me përgjegjësit e sajtit</a>."
 
 #: kuma/wiki/templates/wiki/includes/translate_description.html:6
 msgid "Translate Description"
@@ -5107,8 +6213,12 @@ msgid "Slug in %(locale)s:"
 msgstr "Identifikues për %(locale)s:"
 
 #: kuma/wiki/templates/wiki/includes/translate_description.html:66
-msgid "Find the translation source with the lookup above and then click \"Save Changes."
-msgstr "Gjeni burimet e përkthimit përmes kërkimeve më sipër dhe mandej klikoni mbi \"Ruaji Ndryshimet."
+msgid ""
+"Find the translation source with the lookup above and then click \"Save "
+"Changes."
+msgstr ""
+"Gjeni burimet e përkthimit përmes kërkimeve më sipër dhe mandej klikoni mbi "
+"\"Ruaji Ndryshimet."
 
 #: kuma/wiki/templates/wiki/list/documents.html:2
 #, python-format
@@ -5153,7 +6263,9 @@ msgstr "Krejt dokumentet"
 msgid "Translation updates needed"
 msgstr "Lyp përditësime përkthimi"
 
-#: kuma/wiki/templates/wiki/list/documents.html:60 kuma/wiki/templates/wiki/list/needs_review.html:33 kuma/wiki/templates/wiki/list/with_localization_tags.html:30
+#: kuma/wiki/templates/wiki/list/documents.html:60
+#: kuma/wiki/templates/wiki/list/needs_review.html:33
+#: kuma/wiki/templates/wiki/list/with_localization_tags.html:30
 msgid "There are no articles."
 msgstr "S’ka artikuj."
 
@@ -5232,8 +6344,12 @@ msgstr[0] "U gjet %(count)s dokument."
 msgstr[1] "U gjetën %(count)s dokumente."
 
 #: kuma/wiki/views/delete.py:50
-msgid "Document already exists. Note: You cannot revert a document that has been moved until you delete its redirect."
-msgstr "Dokumenti ekziston tashmë. Shënim: s’mund të ktheni një dokument që është lëvizur, pa fshirë ridrejtimin për të."
+msgid ""
+"Document already exists. Note: You cannot revert a document that has been "
+"moved until you delete its redirect."
+msgstr ""
+"Dokumenti ekziston tashmë. Shënim: s’mund të ktheni një dokument që është "
+"lëvizur, pa fshirë ridrejtimin për të."
 
 #: kuma/wiki/views/document.py:600
 #, python-format
@@ -5264,8 +6380,12 @@ msgid "Sections may only be edited inline."
 msgstr "Ndarjet mund të përpunohen vetëm brendazi."
 
 #: kuma/wiki/views/misc.py:59
-msgid "Autosuggest requires a partial title. For a full document index, see the main page."
-msgstr "Vetësugjerimi lyp një titull të pjesshëm. Për një tregues të plotë dokumenti, shihni faqen kryesore."
+msgid ""
+"Autosuggest requires a partial title. For a full document index, see the "
+"main page."
+msgstr ""
+"Vetësugjerimi lyp një titull të pjesshëm. Për një tregues të plotë "
+"dokumenti, shihni faqen kryesore."
 
 #: kuma/wiki/views/misc.py:141
 msgid "Glad to hear it &mdash; thanks for the feedback!"
@@ -5273,7 +6393,8 @@ msgstr "Lajmi na kënaq &mdash; faleminderit për përshtypjet!"
 
 #: kuma/wiki/views/misc.py:144
 msgid "Sorry to hear that. Perhaps one of the solutions below can help."
-msgstr "Na vjen keq për këtë. Ndoshta mund të ndihmonte një nga zgjidhjet më poshtë."
+msgstr ""
+"Na vjen keq për këtë. Ndoshta mund të ndihmonte një nga zgjidhjet më poshtë."
 
 #: kuma/wiki/views/misc.py:155
 msgid "You already voted on this Article."
@@ -5338,16 +6459,24 @@ msgstr "<li><a href=\"%(login_url)s\">Hyni</a> që të riprovoni.</li>"
 
 #: templates/403.html:53
 #, python-format
-msgid "<li><a href=\"%(demos_url)s\">View demos</a> or <a href=\"%(docs_url)s\">browse docs</a></li>"
-msgstr "<li><a href=\"%(demos_url)s\">Shihni demo</a> ose <a href=\"%(docs_url)s\">shfletoni dokumentime</a></li>"
+msgid ""
+"<li><a href=\"%(demos_url)s\">View demos</a> or <a "
+"href=\"%(docs_url)s\">browse docs</a></li>"
+msgstr ""
+"<li><a href=\"%(demos_url)s\">Shihni demo</a> ose <a "
+"href=\"%(docs_url)s\">shfletoni dokumentime</a></li>"
 
 #: templates/403.html:58
 msgid ""
-"<p class=\"attrib\"><small><a href=\"http://theoatmeal.com/comics/state_web_summer#tumblr\" rel=\"nofollow\">Tumbeasts</a> by Matthew Inman of <a href=\"http://theoatmeal.com\" rel=\"nofollow\">The "
-"Oatmeal</a></small></p>"
+"<p class=\"attrib\"><small><a "
+"href=\"http://theoatmeal.com/comics/state_web_summer#tumblr\" "
+"rel=\"nofollow\">Tumbeasts</a> by Matthew Inman of <a "
+"href=\"http://theoatmeal.com\" rel=\"nofollow\">The Oatmeal</a></small></p>"
 msgstr ""
-"<p class=\"attrib\"><small><a href=\"http://theoatmeal.com/comics/state_web_summer#tumblr\" rel=\"nofollow\">Tumbeasts</a> nga Matthew Inman i <a href=\"http://theoatmeal.com\" rel=\"nofollow\">The "
-"Oatmeal</a></small></p>"
+"<p class=\"attrib\"><small><a "
+"href=\"http://theoatmeal.com/comics/state_web_summer#tumblr\" "
+"rel=\"nofollow\">Tumbeasts</a> nga Matthew Inman i <a "
+"href=\"http://theoatmeal.com\" rel=\"nofollow\">The Oatmeal</a></small></p>"
 
 #: templates/404.html:6
 msgid "Not Found"
@@ -5359,18 +6488,32 @@ msgstr "Na ndjeni, por s’gjetëm dot çfarë po kërkonit."
 
 #: templates/404.html:24
 #, python-format
-msgid "You can try a search or start over on the <a href=\"%(homepage_url)s\">home page</a>."
-msgstr "Mund të provoni të kërkoni, ose t’ia filloni nga e para, te <a href=\"%(homepage_url)s\">faqja hyrëse</a>."
+msgid ""
+"You can try a search or start over on the <a href=\"%(homepage_url)s\">home "
+"page</a>."
+msgstr ""
+"Mund të provoni të kërkoni, ose t’ia filloni nga e para, te <a "
+"href=\"%(homepage_url)s\">faqja hyrëse</a>."
 
 #: templates/404.html:28
 #, python-format
-msgid "If you were following a documentation link, you can sign in and create the page. Otherwise, please <a href=\"%(bug_form_url)s\" rel=\"nofollow\">file a bug</a>. Thanks!"
-msgstr "Nëse ndoqët një lidhje dokumentimi, mund të bëni hyrjen dhe ta krijoni faqen. Përndryshe, ju lutemi, <a href=\"%(bug_form_url)s\" rel=\"nofollow\">njoftoni një të metë</a>. Faleminderit!"
+msgid ""
+"If you were following a documentation link, you can sign in and create the "
+"page. Otherwise, please <a href=\"%(bug_form_url)s\" rel=\"nofollow\">file a"
+" bug</a>. Thanks!"
+msgstr ""
+"Nëse ndoqët një lidhje dokumentimi, mund të bëni hyrjen dhe ta krijoni "
+"faqen. Përndryshe, ju lutemi, <a href=\"%(bug_form_url)s\" "
+"rel=\"nofollow\">njoftoni një të metë</a>. Faleminderit!"
 
 #: templates/404.html:36
 #, python-format
-msgid "<a href=\"%(tumbeasts_url)s\" rel=\"nofollow\">Tumbeasts</a> by Matthew Inman of <a href=\"%(oatmeal_url)s\" rel=\"nofollow\">The Oatmeal</a>"
-msgstr "<a href=\"%(tumbeasts_url)s\" rel=\"nofollow\">Tumbeasts</a> nga Matthew Inman-i i <a href=\"%(oatmeal_url)s\" rel=\"nofollow\">The Oatmeal</a>-it"
+msgid ""
+"<a href=\"%(tumbeasts_url)s\" rel=\"nofollow\">Tumbeasts</a> by Matthew "
+"Inman of <a href=\"%(oatmeal_url)s\" rel=\"nofollow\">The Oatmeal</a>"
+msgstr ""
+"<a href=\"%(tumbeasts_url)s\" rel=\"nofollow\">Tumbeasts</a> nga Matthew "
+"Inman-i i <a href=\"%(oatmeal_url)s\" rel=\"nofollow\">The Oatmeal</a>-it"
 
 #: templates/500.html:5
 msgid "Internal Server Error"
@@ -5494,8 +6637,14 @@ msgstr "Njoftoni një të metë"
 
 #: templates/base.html:199
 #, python-format
-msgid "<p>&copy; 2005-%(thisyear)s Mozilla Developer Network and individual contributors.</p> <p>Content is available under <a href=\"%(copyright_url)s\">these licenses</a>.</p>"
-msgstr "<p>&copy; 2005-%(thisyear)s Mozilla Developer Network dhe kontribues individualë.</p> <p>Lënda mund të përdoret sipas <a href=\"%(copyright_url)s\">këtyre licencave</a>.</p>"
+msgid ""
+"<p>&copy; 2005-%(thisyear)s Mozilla Developer Network and individual "
+"contributors.</p> <p>Content is available under <a "
+"href=\"%(copyright_url)s\">these licenses</a>.</p>"
+msgstr ""
+"<p>&copy; 2005-%(thisyear)s Mozilla Developer Network dhe kontribues "
+"individualë.</p> <p>Lënda mund të përdoret sipas <a "
+"href=\"%(copyright_url)s\">këtyre licencave</a>.</p>"
 
 #: templates/base.html:204
 msgid "About MDN"
@@ -5527,8 +6676,12 @@ msgid "<li><a href=\"/logout\">Log out</a> to try again.</li>"
 msgstr "<li><a href=\"/logout\">Dilni</a> që të riprovoni.</li>"
 
 #: templates/handlers/400.html:40
-msgid "<li><a href=\"/demos\">View demos</a> or <a href=\"/docs\">browse docs</a></li>"
-msgstr "<li><a href=\"/demos\">Shihni demo</a> ose <a href=\"/docs\">shfletoni dokumentime</a></li>"
+msgid ""
+"<li><a href=\"/demos\">View demos</a> or <a href=\"/docs\">browse "
+"docs</a></li>"
+msgstr ""
+"<li><a href=\"/demos\">Shihni demo</a> ose <a href=\"/docs\">shfletoni "
+"dokumentime</a></li>"
 
 #: templates/includes/common_macros.html:18
 msgid "Search Firefox Help"
@@ -5556,8 +6709,12 @@ msgid "Sign in"
 msgstr "Hyni"
 
 #: templates/includes/newsletter.html:6
-msgid "Subscribe for periodic news about Firefox OS, Firefox Marketplace and the Open Web apps ecosystem."
-msgstr "Pajtohuni te lajme periodike mbi Firefox OS-in, Firefox Marketplace-in dhe ekosistemin e aplikacioneve të Web-it të Hapur."
+msgid ""
+"Subscribe for periodic news about Firefox OS, Firefox Marketplace and the "
+"Open Web apps ecosystem."
+msgstr ""
+"Pajtohuni te lajme periodike mbi Firefox OS-in, Firefox Marketplace-in dhe "
+"ekosistemin e aplikacioneve të Web-it të Hapur."
 
 #: templates/includes/newsletter.html:35
 #, python-format
@@ -5568,7 +6725,9 @@ msgstr "te <a href=\"%(privacy_url)s\">Rregullat e Privatësisë</a>"
 msgid "Unsubscribe from these emails:"
 msgstr "Shpajtojini këta email-e:"
 
-#: templates/tidings/unsubscribe.html:2 templates/tidings/unsubscribe.html:12 templates/tidings/unsubscribe_error.html:2 templates/tidings/unsubscribe_success.html:2
+#: templates/tidings/unsubscribe.html:2 templates/tidings/unsubscribe.html:12
+#: templates/tidings/unsubscribe_error.html:2
+#: templates/tidings/unsubscribe_success.html:2
 msgid "Unsubscribe"
 msgstr "Çregjistrohu"
 
@@ -5582,11 +6741,17 @@ msgstr "Gabim Shpajtimi"
 
 #: templates/tidings/unsubscribe_error.html:10
 msgid ""
-"We could not find your subscription. Either it has already been cancelled, or there was a mistake in the unsubscribe link. Please make sure the entire link from the email made it into the browser. "
-"If the last part of the link wraps onto a second line in the email, try copying and pasting the link into the browser."
+"We could not find your subscription. Either it has already been cancelled, "
+"or there was a mistake in the unsubscribe link. Please make sure the entire "
+"link from the email made it into the browser. If the last part of the link "
+"wraps onto a second line in the email, try copying and pasting the link into"
+" the browser."
 msgstr ""
-"S’e gjetëm dot regjistrimin tuaj. Ose është fshirë tashmë, ose pati një gabim te lidhja e çregjistrimit. Ju lutemi, sigurohuni që u kopjua te shfletuesi krejt lidhja prej email-it. Nëse pjesa e "
-"fundit e lidhjes mbështillet në një rresht të dytë te email-i, provoni ta kopjoni dhe ta hidhni lidhjen te shfletuesi."
+"S’e gjetëm dot regjistrimin tuaj. Ose është fshirë tashmë, ose pati një "
+"gabim te lidhja e çregjistrimit. Ju lutemi, sigurohuni që u kopjua te "
+"shfletuesi krejt lidhja prej email-it. Nëse pjesa e fundit e lidhjes "
+"mbështillet në një rresht të dytë te email-i, provoni ta kopjoni dhe ta "
+"hidhni lidhjen te shfletuesi."
 
 #: templates/tidings/unsubscribe_success.html:7
 msgid "Unsubscribed"

--- a/locale/sq/LC_MESSAGES/django.po
+++ b/locale/sq/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2015-12-19 09:40-0800\n"
-"PO-Revision-Date: 2015-12-24 17:45+0000\n"
+"PO-Revision-Date: 2015-12-24 18:16+0000\n"
 "Last-Translator: Besnik Bleta <besnik@programeshqip.org>\n"
 "Language-Team: sq\n"
 "Language: sq\n"
@@ -335,9 +335,9 @@ msgid "Content deleted by moderator"
 msgstr "Lëndë e fshirë nga moderatori"
 
 #: kuma/contentflagging/models.py:65
-#, fuzzy, python-format
+#, python-format
 msgid "%(object)s Flagged"
-msgstr "{object} Me Shenjë"
+msgstr "%(object)s Me Shenjë"
 
 #: kuma/contentflagging/models.py:97
 msgid "current status of flag review"
@@ -3733,9 +3733,9 @@ msgid "Username already in use."
 msgstr "Ky emër përdoruesi është tashmë në përdorim."
 
 #: kuma/users/helpers.py:35
-#, fuzzy, python-format
+#, python-format
 msgid "Banned on %(ban_date)s by %(ban_admin)s."
-msgstr "Përzënë më {ban_date} nga {ban_admin}."
+msgstr "Përzënë më %(ban_date)s nga %(ban_admin)s."
 
 #: kuma/users/helpers.py:42
 msgid "Banned"
@@ -4806,9 +4806,9 @@ msgid "Edit section"
 msgstr "Përpunoni ndarjen"
 
 #: kuma/wiki/events.py:72
-#, fuzzy, python-format
+#, python-format
 msgid "[MDN] Page \"%(document_title)s\" changed by %(creator)s"
-msgstr "[MDN] Faqja \"{document_title}\" u ndryshua nga {creator}"
+msgstr "[MDN] Faqja \"%(document_title)s\" u ndryshua nga %(creator)s"
 
 #: kuma/wiki/feeds.py:27
 msgid "MDN documents"
@@ -5378,7 +5378,7 @@ msgid "contributors"
 msgstr "pjesëmarrës"
 
 #: kuma/wiki/templates/wiki/document.html:184
-#, fuzzy, python-format
+#, python-format
 msgid "by %(count)s contributor:"
 msgid_plural "by %(count)s contributors:"
 msgstr[0] "nga %(count)s pjesëmarrës:"
@@ -5452,13 +5452,14 @@ msgid "This translation is in progress."
 msgstr "Përkthimi është në kryerje e sipër."
 
 #: kuma/wiki/templates/wiki/document.html:308
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "Our volunteers haven't translated this article into <bdi>%(locale)s</bdi> "
 "yet. <a href=\"%(help_link)s\">Join us and help get the job done!</a>"
 msgstr ""
-"Vullnetarët tanë s’e kanë përkthyer ende në %(locale)s këtë artikull. <a "
-"href=\"%(help_link)s\">Bashkohuni dhe ndihmoni të mbarohet kjo punë!</a>"
+"Vullnetarët tanë s’e kanë përkthyer ende në <bdi>%(locale)s</bdi> këtë "
+"artikull. <a href=\"%(help_link)s\">Merrni pjesë dhe ndihmoni të mbarohet "
+"kjo punë!</a>"
 
 #: kuma/wiki/templates/wiki/document.html:319
 msgid "This article doesn't have any content yet."

--- a/locale/sq/LC_MESSAGES/javascript.po
+++ b/locale/sq/LC_MESSAGES/javascript.po
@@ -1,9 +1,10 @@
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2015-12-19 09:39-0800\n"
-"PO-Revision-Date: 2015-11-21 17:09+0200\n"
+"PO-Revision-Date: 2015-12-24 17:42+0000\n"
 "Last-Translator: Besnik Bleta <besnik@programeshqip.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: sq\n"
@@ -11,8 +12,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Translate Toolkit 1.13.0\n"
 "Generated-By: Babel 2.0\n"
+"X-Generator: Pontoon\n"
 "X-POOTLE-MTIME: 1383819910.0\n"
 
 #: kuma/static/js/components.js:75
@@ -100,7 +101,6 @@ msgid "Open"
 msgstr "Hape"
 
 #: kuma/static/js/wiki-compat-tables.js:25
-#, fuzzy
 msgid "Return to compatibility table."
 msgstr "Rikthehuni te tabela e përputhshmërive."
 
@@ -133,8 +133,14 @@ msgid "Show old table."
 msgstr "Shfaq tabelën e vjetër."
 
 #: kuma/static/js/wiki-edit.js:400
-msgid "You have a draft in progress. <a href=\"\" class=\"restoreLink\">Restore the draft content</a> or <a href=\"\" class=\"discardLink\">discard the draft</a>."
-msgstr "Keni në përpunim një skicë. <a href=\"\" class=\"restoreLink\">Riktheni lëndën e skicës</a> ose <a href=\"\" class=\"discardLink\">hidheni skicën tej</a>."
+msgid ""
+"You have a draft in progress. <a href=\"\" class=\"restoreLink\">Restore the"
+" draft content</a> or <a href=\"\" class=\"discardLink\">discard the "
+"draft</a>."
+msgstr ""
+"Keni në përpunim një skicë. <a href=\"\" class=\"restoreLink\">Riktheni "
+"lëndën e skicës</a> ose <a href=\"\" class=\"discardLink\">hidheni skicën "
+"tej</a>."
 
 #: kuma/static/js/wiki-edit.js:547
 msgid "saved"
@@ -153,7 +159,8 @@ msgid "Search Stack Overflow"
 msgstr "Kërkoni te Stack Overflow"
 
 #: kuma/static/js/wiki.js:684
-msgid "Your browser does not support MathML. A CSS fallback has been used instead."
+msgid ""
+"Your browser does not support MathML. A CSS fallback has been used instead."
 msgstr "Shfletuesi juaj nuk mbulon MathML. Në vend të tij është përdorur CSS."
 
 #: kuma/static/js/wiki.js:899
@@ -168,7 +175,8 @@ msgstr "Përzgjidhni një bashkëngjitje"
 msgid "No attachments available"
 msgstr "S’ka bashkëngjitje"
 
-#: kuma/static/js/libs/ckeditor/source/plugins/mdn-image-attachment/plugin.js:23 kuma/static/js/libs/ckeditor/source/plugins/mdn-link-customization/plugin.js:130
+#: kuma/static/js/libs/ckeditor/source/plugins/mdn-image-attachment/plugin.js:23
+#: kuma/static/js/libs/ckeditor/source/plugins/mdn-link-customization/plugin.js:130
 msgid "Attachments"
 msgstr "Bashkangjitje"
 
@@ -188,7 +196,8 @@ msgstr "Krijoni një Ridrejtim"
 msgid "MDN Redirect"
 msgstr "Ridrejtim MDN-je"
 
-#: kuma/static/js/libs/ckeditor/source/plugins/mdn-redirect/dialogs/mdn-redirect.js:23 kuma/static/js/libs/ckeditor/source/plugins/mdn-sample-finder/dialogs/mdn-sample-finder.js:44
+#: kuma/static/js/libs/ckeditor/source/plugins/mdn-redirect/dialogs/mdn-redirect.js:23
+#: kuma/static/js/libs/ckeditor/source/plugins/mdn-sample-finder/dialogs/mdn-sample-finder.js:44
 msgid "Document"
 msgstr "Dokument"
 
@@ -198,7 +207,7 @@ msgstr "URL"
 
 #: kuma/static/js/libs/ckeditor/source/plugins/mdn-sample-finder/plugin.js:17
 msgid "Insert Code Sample iFrame"
-msgstr ""
+msgstr "Futni iFrame Shembull Kodi"
 
 #: kuma/static/js/libs/ckeditor/source/plugins/mdn-sample-finder/dialogs/mdn-sample-finder.js:5
 msgid "Sample Finder"
@@ -242,7 +251,7 @@ msgstr "Shembull Lënde JavaScript"
 
 #: kuma/static/js/libs/ckeditor/source/plugins/mdn-sampler/plugin.js:52
 msgid "Insert Code Sample Template"
-msgstr ""
+msgstr "Futni Gjedhe Shembull Kodi"
 
 #: kuma/static/js/libs/ckeditor/source/plugins/mdn-syntaxhighlighter/plugin.js:24
 msgid "Syntax Highlighter"


### PR DESCRIPTION
This commit removes the tip class from the https://github.com/mozilla/kuma/blob/36220986307fd18eeac275b9c3058d7ccae40565/kuma/static/styles/components/content.styl#L257